### PR TITLE
docs: Consistently use env production

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ $ wrangler deploy --env production
 Your registry should be up and running. It will refuse any requests if you don't setup credentials.
 
 ### Adding username password based authentication
-Set the USERNAME and PASSWORD as secrets with `wrangler secret put USERNAME` and `wrangler secret put PASSWORD`.
+Set the USERNAME and PASSWORD as secrets with `wrangler secret put USERNAME --env production` and `wrangler secret put PASSWORD --env production`.
 
 ### Adding JWT authentication with public key
 You can add a base64 encoded JWT public key to verify passwords (or token) that are signed by the private key.
-`wrangler secret put JWT_REGISTRY_TOKENS_PUBLIC_KEY`
+`wrangler secret put JWT_REGISTRY_TOKENS_PUBLIC_KEY --env production`
 
 ### Known limitations
 Right now there is some limitations with this docker registry.


### PR DESCRIPTION
When I tried this I got two workers, `r2-registry` and `r2-registry-production`, due to the commands largely adding `--env production`

Since that wasn't present for the `secret put` commands they went to the `r2-registry` worker instead of the `-production` one, causing me to experience some confusion about why the secret change wasn't taking effect.

This resolves that by adding `--env production` to the secret commands too. There could be an argument to made that removing it from all the commands works too, but this option seemed less destructive to the current instructions