### PR TITLE
  Add a way to configure passthrough registries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "@tsndr/cloudflare-worker-jwt": "^2.2.1",
-        "itty-router": "^4.0.9"
+        "itty-router": "^4.0.9",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20231002.0",
@@ -4101,10 +4102,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
-      "dev": true,
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6841,10 +6841,9 @@
       }
     },
     "zod": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz",
-      "integrity": "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==",
-      "dev": true
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@tsndr/cloudflare-worker-jwt": "^2.2.1",
-    "itty-router": "^4.0.9"
+    "itty-router": "^4.0.9",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231002.0",

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -1,0 +1,33 @@
+import { Env } from "../..";
+import { errorString } from "../utils";
+import z from "zod";
+
+// Defines a registry and how it's configured
+const registryConfiguration = z.object({
+  registry: z.string().url(),
+  password_env: z.string(),
+  username: z.string(),
+});
+
+export type RegistryConfiguration = z.infer<typeof registryConfiguration>;
+
+export function registries(env: Env): RegistryConfiguration[] {
+  if (env.REGISTRIES_JSON === undefined || env.REGISTRIES_JSON.length === 0) {
+    return [];
+  }
+
+  try {
+    const jsonObject = JSON.parse(env.REGISTRIES_JSON);
+    return registryConfiguration.array().parse(jsonObject);
+  } catch (err) {
+    console.error("Error parsing registries JSON: " + errorString(err));
+    return [];
+  }
+}
+
+// RegistryHTTPClient implements a registry client that is able to pull/push to the configured registry
+export class RegistryHTTPClient {
+  constructor(private env: Env, private configuration: RegistryConfiguration) {}
+
+  // todo: implementation
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { ZodError } from "zod";
+
 export async function readableToBlob(
   reader: ReadableStreamDefaultReader,
   ...multiwriters: WritableStreamDefaultWriter[]
@@ -41,4 +43,19 @@ export async function consumeReadable(reader: ReadableStreamDefaultReader) {
     const value = await reader.read();
     if (value.done) break;
   }
+}
+
+export function errorString(err: unknown): string {
+  if (err instanceof ZodError) {
+    const errorsMsg = err.errors
+      .map((zodIssue) => `- ${zodIssue.code}: ${zodIssue.message}: ${zodIssue.path}`)
+      .join("\n\t");
+    return `zod error: ${errorsMsg}`;
+  }
+
+  if (err instanceof Error) {
+    return `error ${err.name}: ${err.message}: ${err.cause}: ${err.stack}`;
+  }
+
+  return "unknown error: " + JSON.stringify(err);
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,6 +36,7 @@ kv_namespaces = [
     { binding = "UPLOADS", id = "abcd" }
 ]
 [env.dev.vars]
+REGISTRIES_JSON = "[{ \"registry\": \"localhost:9999\", \"password_env\": \"PASSWORD\", \"username\": \"hello\" }]"
 JWT_STATE_SECRET = "HELLO"
 USERNAME="hello"
 PASSWORD="world"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,7 +1890,7 @@
     "mustache" "^4.2.0"
     "stacktracey" "^2.1.8"
 
-"zod@^3.20.6":
-  "integrity" "sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg=="
-  "resolved" "https://registry.npmjs.org/zod/-/zod-3.22.2.tgz"
-  "version" "3.22.2"
+"zod@^3.20.6", "zod@^3.22.4":
+  "integrity" "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
+  "resolved" "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz"
+  "version" "3.22.4"


### PR DESCRIPTION
We want to allow users of the registry to be able to lazily move from
one registry to other and viceversa at some point.

Let's add a way to configure that.

Right now we expose it as a configuration that should be set under
[vars].

If empty or not set it should always be no-op for other users.

The schema is defined as a zod object like this:
 - "registry" should be the url of the target registry.
 - "password_env" should be the name of the environment variable that
   contains the registry password.
 - "username" should be a valid username to use on the target registry.

Related to issue https://github.com/cloudflare/serverless-registry/issues/4.

The PR is divided in a commit where we add zod, and a second commit where we actually expose the configuration and parse it in `registries()`

There is also extra error handling in the root fetch of the worker so it's easier to debug unexpected issues.