### PR TITLE
fix: type errors and lints in listManifests

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -24,14 +24,28 @@ export class AuthErrorResponse extends Response {
 
 export class RangeError extends Response {
   constructor(stateStr: string, state: State) {
-    super("{}", {
-      status: 416,
-      headers: {
-        "Location": `/v2/${state.name}/blobs/uploads/${state.registryUploadId}?_state=${stateStr}`,
-        "Range": `0-${state.byteRange - 1}`,
-        "Docker-Upload-UUID": state.registryUploadId,
+    super(
+      JSON.stringify({
+        errors: [
+          {
+            code: "RANGE_ERROR",
+            message: `state ${stateStr} is not satisfiable (upload id: ${state.registryUploadId})`,
+            detail: {
+              ...state,
+              string: stateStr,
+            },
+          },
+        ],
+      }),
+      {
+        status: 416,
+        headers: {
+          "Location": `/v2/${state.name}/blobs/uploads/${state.registryUploadId}?_state=${stateStr}`,
+          "Range": `0-${state.byteRange - 1}`,
+          "Docker-Upload-UUID": state.registryUploadId,
+        },
       },
-    });
+    );
   }
 }
 

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -7,6 +7,7 @@ import {
   FinishedUploadObject,
   GetLayerResponse,
   GetManifestResponse,
+  ListRepositoriesResponse,
   PutManifestResponse,
   Registry,
   RegistryConfiguration,
@@ -64,7 +65,6 @@ function ctxIntoRequest(ctx: HTTPContext, url: URL, method: string, path: string
   const urlReq = `${url.protocol}//${ctx.authContext.service}/v2${
     ctx.repository === "" ? "/" : ctx.repository + "/"
   }${path}`;
-  console.log("Doing request:", urlReq);
   return new Request(urlReq, {
     method,
     body,
@@ -465,6 +465,10 @@ export class RegistryHTTPClient implements Registry {
     _stream?: ReadableStream<any> | undefined,
     _length?: number | undefined,
   ): Promise<RegistryError | FinishedUploadObject> {
+    throw new Error("unimplemented");
+  }
+
+  async listRepositories(_limit?: number, _last?: string): Promise<RegistryError | ListRepositoriesResponse> {
     throw new Error("unimplemented");
   }
 }

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -43,11 +43,10 @@ export type CheckManifestResponse =
       exists: false;
     };
 
-export type ListRepositoriesResponse =
-  {
-    repositories: string[];
-  }
-
+export type ListRepositoriesResponse = {
+  repositories: string[];
+  cursor?: string;
+};
 
 // Response layerExists call
 export type CheckLayerResponse =


### PR DESCRIPTION
We also need to do a tweak in listManifests where we are able to return a repository with multiple components in the path.
Added a unit test to showcase it works.
Also adding more context to RangeError.