### PR TITLE
fix: Use R2 bucket to store state tracking instead of KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Username/Password and public key JWT based authentication.
 ### Deployment
 
 You have to install all the dependencies with your favorite package manager (e.g pnpm, npm, yarn, bun...).
+
 ```bash
 $ npm install
 ```
@@ -17,36 +18,25 @@ After installation, there is a few steps to actually deploy the registry into pr
 1. Setup the R2 Bucket for this registry
 
 ```bash
-$ wrangler --env production r2 bucket create r2-registry 
+$ wrangler --env production r2 bucket create r2-registry
 ```
 
 Add this to your `wrangler.toml`
+
 ```
 r2_buckets = [
     { binding = "REGISTRY", bucket_name = "r2-registry"}
 ]
 ```
 
-2. Setup the KV namespace for this registry
-
-```bash
-$ wrangler --env production kv:namespace create r2_registry_uploads 
-```
-
-Add the namespace id to your `wrangler.toml`
-```
-kv_namespaces = [
-    { binding = "UPLOADS", id = "<namespace-id-here>"}
-]
-```
-
-3. Setup the JWT_STATE_SECRET secret binding
+2. Setup the JWT_STATE_SECRET secret binding
 
 ```bash
 $ node -p 'crypto.randomUUID()' | wrangler --env production secret put JWT_STATE_SECRET
 ```
 
-4. Deploy your image registry
+3. Deploy your image registry
+
 ```bash
 $ wrangler deploy --env production
 ```
@@ -54,13 +44,16 @@ $ wrangler deploy --env production
 Your registry should be up and running. It will refuse any requests if you don't setup credentials.
 
 ### Adding username password based authentication
+
 Set the USERNAME and PASSWORD as secrets with `wrangler secret put USERNAME --env production` and `wrangler secret put PASSWORD --env production`.
 
 ### Adding JWT authentication with public key
+
 You can add a base64 encoded JWT public key to verify passwords (or token) that are signed by the private key.
 `wrangler secret put JWT_REGISTRY_TOKENS_PUBLIC_KEY --env production`
 
 ### Known limitations
+
 Right now there is some limitations with this docker registry.
 
 - Pushing with docker is limited to images that have layers of maximum size 500MB. Refer to maximum request body sizes in your Workers plan.

--- a/index.ts
+++ b/index.ts
@@ -89,13 +89,6 @@ const ensureConfig = (env: Env): boolean => {
     return false;
   }
 
-  if (!env.UPLOADS) {
-    console.error(
-      "env.UPLOADS is not setup. Please setup a KV namespace and add the binding in wrangler.toml. Try 'wrangler --env production kv:namespace create r2_registry_uploads'",
-    );
-    return false;
-  }
-
   if (!env.JWT_STATE_SECRET) {
     console.error(
       `env.JWT_STATE_SECRET is not set. Please setup this secret using wrnagler. Try 'echo \`node -e "console.log(crypto.randomUUID())"\` | wrangler --env production secret put JWT_STATE_SECRET'`,

--- a/index.ts
+++ b/index.ts
@@ -20,7 +20,6 @@ export interface Env {
   USERNAME?: string;
   PASSWORD?: string;
   JWT_STATE_SECRET: string;
-  UPLOADS: KVNamespace;
   PUSH_COMPATIBILITY_MODE?: PushCompatibilityMode;
   REGISTRIES_JSON?: string; // should be in the format of RegistryConfiguration[];
   REGISTRY_CLIENT: Registry;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     // API options here:
     environmentOptions: {
       r2Buckets: ["REGISTRY"],
-      kvNamespaces: ["UPLOADS"],
     },
   },
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,8 +7,9 @@ compatibility_flags = ["streams_enable_constructors"]
 
 ## Production
 [env.production]
-r2_buckets = [{ binding = "REGISTRY", bucket_name = "" }]
-kv_namespaces = [{ binding = "UPLOADS", id = "" }]
+r2_buckets = [
+  { binding = "REGISTRY", bucket_name = "" }
+]
 
 [env.production.vars]
 JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
@@ -24,9 +25,8 @@ JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
 ## Dev - For local dev using `wrangler dev`
 [env.dev]
 r2_buckets = [{ binding = "REGISTRY", bucket_name = "r2-image-registry-dev" }]
-kv_namespaces = [{ binding = "UPLOADS", id = "abcd" }]
 [env.dev.vars]
-REGISTRIES_JSON = "[{ \"registry\": \"http://localhost:9999\", \"password_env\": \"PASSWORD\", \"username\": \"hello\" }]"
+# REGISTRIES_JSON = "[{ \"registry\": \"http://localhost:9999\", \"password_env\": \"PASSWORD\", \"username\": \"hello\" }]"
 JWT_STATE_SECRET = "HELLO"
 USERNAME = "hello"
 PASSWORD = "world"


### PR DESCRIPTION
Fix https://github.com/cloudflare/serverless-registry/issues/20

We should use a store mechanism that has bigger consistency guarantees than K/V.