### PR TITLE
16k url length limit fix

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,16 +23,16 @@ export class AuthErrorResponse extends Response {
 }
 
 export class RangeError extends Response {
-  constructor(stateStr: string, state: State) {
+  constructor(stateHash: string, state: State) {
     super(
       JSON.stringify({
         errors: [
           {
             code: "RANGE_ERROR",
-            message: `state ${stateStr} is not satisfiable (upload id: ${state.registryUploadId})`,
+            message: `stateHash ${stateHash} does not match state (upload id: ${state.registryUploadId})`,
             detail: {
               ...state,
-              string: stateStr,
+              string: stateHash,
             },
           },
         ],
@@ -40,7 +40,7 @@ export class RangeError extends Response {
       {
         status: 416,
         headers: {
-          "Location": `/v2/${state.name}/blobs/uploads/${state.registryUploadId}?_state=${stateStr}`,
+          "Location": `/v2/${state.name}/blobs/uploads/${state.registryUploadId}?_stateHash=${stateHash}`,
           "Range": `0-${state.byteRange - 1}`,
           "Docker-Upload-UUID": state.registryUploadId,
         },

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -450,6 +450,7 @@ export class RegistryHTTPClient implements Registry {
 
   async uploadChunk(
     _namespace: string,
+    _uploadId: string,
     _location: string,
     _stream: ReadableStream<any>,
     _length?: number | undefined,
@@ -460,6 +461,7 @@ export class RegistryHTTPClient implements Registry {
 
   finishUpload(
     _namespace: string,
+    _uploadId: string,
     _location: string,
     _expectedSha: string,
     _stream?: ReadableStream<any> | undefined,

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -10,7 +10,7 @@ import {
   split,
 } from "../chunk";
 import { InternalError, RangeError, ServerError } from "../errors";
-import { SHA256_PREFIX_LEN, hexToDigest } from "../user";
+import { SHA256_PREFIX_LEN, getSHA256, hexToDigest } from "../user";
 import { readableToBlob, readerToBlob, wrap } from "../utils";
 import { BlobUnknownError, ManifestUnknownError } from "../v2-errors";
 import {
@@ -85,7 +85,7 @@ export async function getJWT(env: Env, state: { registryUploadId: string; name: 
   }
 }
 
-export async function encodeState(state: State, env: Env): Promise<string> {
+export async function encodeState(state: State, env: Env): Promise<{jwt: string, hash: string}> {
   // 2h timeout
   const jwtSignature = await jwt.sign(
     { ...state, exp: Math.floor(Date.now() / 1000) + 60 * 60 * 2 },
@@ -96,31 +96,30 @@ export async function encodeState(state: State, env: Env): Promise<string> {
   );
 
   await env.REGISTRY.put(getRegistryUploadsPath(state), JSON.stringify({ jwt: jwtSignature }));
-  return jwtSignature;
+  return {jwt: jwtSignature, hash: await getSHA256(jwtSignature)};
 }
 
-export async function decodeStateString(
-  state: string,
-  env: Env,
-  skipKVVerification = false,
-): Promise<State | RangeError> {
-  const ok = await jwt.verify(state, env.JWT_STATE_SECRET, { algorithm: "HS256" });
+export async function getUploadState(name: string, uploadId: string, env: Env, verifyHash: string | undefined): Promise<{state: State, stateStr: string, hash: string} | RangeError | null> {
+  const stateStr = await getJWT(env, { registryUploadId: uploadId, name: name });
+  if (stateStr === null) {
+    return null;
+  }
+  const stateStrHash = await getSHA256(stateStr);
+  
+  const ok = await jwt.verify(stateStr, env.JWT_STATE_SECRET, { algorithm: "HS256" }); // Ivan: We don't really need jwt anymore (currently it only checks for 2 hrs expiration)
   if (!ok) {
     throw new InternalError();
   }
-
-  const stateObject = jwt.decode(state).payload as unknown as State;
-  if (!skipKVVerification) {
-    const lastState = await getJWT(env, stateObject);
-    if (lastState !== null && lastState !== state) {
-      const s = await decodeStateString(lastState, env);
-      if (s instanceof RangeError) return s;
-      return new RangeError(lastState, s);
-    }
+  const stateObject = jwt.decode<State>(stateStr).payload;
+  if (!stateObject) {
+    throw new InternalError();
   }
-
-  return stateObject;
+  if (!verifyHash && stateStrHash !== verifyHash) {
+    return new RangeError(stateStrHash, stateObject);
+  }
+  return {state: stateObject, stateStr: stateStr, hash: stateStrHash};
 }
+
 
 export class R2Registry implements Registry {
   constructor(private env: Env) {}
@@ -360,69 +359,69 @@ export class R2Registry implements Registry {
       name: namespace,
       chunks: [],
     };
-    const stateStr = await encodeState(state, this.env);
+    const hashedJwtState = await encodeState(state, this.env);
     return {
       maximumBytesPerChunk: MAXIMUM_CHUNK_UPLOAD_SIZE,
       minimumBytesPerChunk: MINIMUM_CHUNK,
       id: uuid,
-      location: `/v2/${namespace}/blobs/uploads/${uuid}?_state=${stateStr}`,
+      location: `/v2/${namespace}/blobs/uploads/${uuid}?_stateHash=${hashedJwtState.hash}`,
       range: [0, 0],
     };
   }
 
   async getUpload(namespace: string, uploadId: string): Promise<UploadObject | RegistryError> {
-    const stateStr = await getJWT(this.env, { registryUploadId: uploadId, name: namespace });
-    if (stateStr === null) {
+    const state = await getUploadState(namespace, uploadId, this.env, undefined);
+    if (state === null) {
       return {
         response: new Response(null, { status: 404 }),
       };
     }
-
-    const state = await decodeStateString(stateStr, this.env, true);
     // kind of unreachable, as RangeErrors are only thrown for invalid states
     if (state instanceof RangeError) {
       return { response: new InternalError() };
     }
 
     return {
-      id: state.registryUploadId,
+      id: uploadId,
       maximumBytesPerChunk: MAXIMUM_CHUNK_UPLOAD_SIZE,
       minimumBytesPerChunk: MINIMUM_CHUNK,
-      location: `/v2/${namespace}/blobs/uploads/${state.registryUploadId}?_state=${stateStr}`,
+      location: `/v2/${namespace}/blobs/uploads/${uploadId}?_stateHash=${state.hash}`,
       // Note that the HTTP Range header byte ranges are inclusive and that will be honored, even in non-standard use cases.
-      range: [0, state.byteRange - 1],
+      range: [0, state.state.byteRange - 1],
     };
   }
 
   async uploadChunk(
     namespace: string,
+    uploadId: string,
     location: string,
     stream: ReadableStream<any>,
     length?: number | undefined,
     range?: [number, number] | undefined,
   ): Promise<RegistryError | UploadObject> {
     const urlObject = new URL("https://r2-registry.com" + location);
-    const stateString = urlObject.searchParams.get("_state");
-    if (!stateString) {
-      console.error("No state string on", urlObject.toString());
-      return {
-        response: new InternalError(),
-      };
+    const stateHash = urlObject.searchParams.get("_stateHash");
+    if (stateHash === null) {
+      console.error("State hash is missing");
+      return { response: new InternalError() };
     }
 
-    const state = await decodeStateString(stateString, this.env);
-    if (state instanceof RangeError)
+    const hashedState = await getUploadState(namespace, uploadId, this.env, stateHash);
+    if (hashedState instanceof RangeError)
       return {
-        response: state,
+        response: hashedState,
       };
-
+    const state = hashedState?.state;
+    if (!state) {
+      return { response: new InternalError() };
+    }
     const [start, end] = range ?? [undefined, undefined];
     if (
       start !== undefined &&
       end !== undefined &&
       (state.byteRange !== +start || state.byteRange >= +end || +start >= +end)
     ) {
-      return { response: new RangeError(stateString, state) };
+      return { response: new RangeError(stateHash, state) };
     }
 
     if (state.parts.length >= 10000) {
@@ -546,7 +545,7 @@ export class R2Registry implements Registry {
         throw new ServerError("unreachable", 500);
       }
 
-      return new RangeError(stateString as string, state);
+      return new RangeError(stateHash, state);
     };
 
     if (length === undefined) {
@@ -563,33 +562,39 @@ export class R2Registry implements Registry {
         response: res,
       };
 
-    const stateStr = await encodeState(state, env);
+    const hashedJwtState = await encodeState(state, env);
     return {
       id: uuid,
       range: [0, state.byteRange - 1],
-      location: `/v2/${namespace}/blobs/uploads/${uuid}?_state=${stateStr}`,
+      location: `/v2/${namespace}/blobs/uploads/${uuid}?_stateHash=${hashedJwtState.hash}`,
     };
   }
 
   async finishUpload(
     namespace: string,
+    uploadId: string,
     location: string,
     expectedSha: string,
     stream?: ReadableStream<any> | undefined,
     length?: number | undefined,
   ): Promise<RegistryError | FinishedUploadObject> {
     const urlObject = new URL("https://r2-registry.com" + location);
-    const stateString = urlObject.searchParams.get("_state");
-    if (stateString === null) {
-      console.error("State string is empty");
+    const stateHash = urlObject.searchParams.get("_stateHash");
+    if (stateHash === null) {
+      console.error("State hash is missing");
       return { response: new InternalError() };
     }
 
-    const state = await decodeStateString(stateString, this.env);
-    if (state instanceof RangeError)
+    const hashedState = await getUploadState(namespace, uploadId, this.env, stateHash);
+    if (hashedState instanceof RangeError) {
       return {
-        response: state,
+        response: hashedState,
       };
+    }
+    if (hashedState === null || !hashedState.state) {
+      return { response: new InternalError() };
+    }
+    const state = hashedState.state;
 
     const uuid = state.registryUploadId;
     if (state.parts.length === 0) {
@@ -622,9 +627,9 @@ export class R2Registry implements Registry {
       await put;
       await this.env.REGISTRY.delete(uuid);
     }
-    
+
     await this.env.REGISTRY.delete(getRegistryUploadsPath(state));
-    
+
     return {
       digest: expectedSha,
       location: `/v2/${namespace}/blobs/${expectedSha}`,
@@ -632,15 +637,14 @@ export class R2Registry implements Registry {
   }
 
   async cancelUpload(name: string, uploadId: UploadId): Promise<true | RegistryError> {
-    const lastState = await getJWT(this.env, { name, registryUploadId: uploadId });
-    if (!lastState) {
+    const hashedState = await getUploadState(name, uploadId, this.env, undefined);
+    if (hashedState instanceof RangeError) {
       return { response: new InternalError() };
     }
-
-    const state = await decodeStateString(lastState, this.env);
-    if (state instanceof RangeError) {
+    if (hashedState === null || !hashedState.state) {
       return { response: new InternalError() };
     }
+    const state = hashedState.state;
 
     const upload = this.env.REGISTRY.resumeMultipartUpload(state.registryUploadId, state.uploadId);
     await upload.abort();

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -96,7 +96,7 @@ export async function encodeState(state: State, env: Env): Promise<{jwt: string,
   );
 
   await env.REGISTRY.put(getRegistryUploadsPath(state), JSON.stringify({ jwt: jwtSignature }));
-  return {jwt: jwtSignature, hash: await getSHA256(jwtSignature)};
+  return {jwt: jwtSignature, hash: await getSHA256(jwtSignature, "")};
 }
 
 export async function getUploadState(name: string, uploadId: string, env: Env, verifyHash: string | undefined): Promise<{state: State, stateStr: string, hash: string} | RangeError | null> {
@@ -104,7 +104,7 @@ export async function getUploadState(name: string, uploadId: string, env: Env, v
   if (stateStr === null) {
     return null;
   }
-  const stateStrHash = await getSHA256(stateStr);
+  const stateStrHash = await getSHA256(stateStr, "");
   
   const ok = await jwt.verify(stateStr, env.JWT_STATE_SECRET, { algorithm: "HS256" }); // Ivan: We don't really need jwt anymore (currently it only checks for 2 hrs expiration)
   if (!ok) {

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -149,6 +149,7 @@ export interface Registry {
   // uploads a chunk
   uploadChunk(
     namespace: string,
+    uploadId: string,
     location: string,
     stream: ReadableStream,
     // for a more optimal upload. Some clients might require it
@@ -159,6 +160,7 @@ export interface Registry {
   // finishes an upload
   finishUpload(
     namespace: string,
+    uploadId: string,
     location: string,
     expectedDigest: string,
     stream?: ReadableStream,

--- a/src/router.ts
+++ b/src/router.ts
@@ -384,7 +384,7 @@ v2Router.get("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
 });
 
 v2Router.patch("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
-  const { name } = req.params;
+  const { name, uuid } = req.params;
   const contentRange = req.headers.get("Content-Range");
   const [start, end] = contentRange?.split("-") ?? [undefined, undefined];
   if (req.body == null) {
@@ -403,6 +403,7 @@ v2Router.patch("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
   const [res, err] = await wrap<UploadObject | RegistryError, Error>(
     env.REGISTRY_CLIENT.uploadChunk(
       name,
+      uuid,
       url.pathname + "?" + url.searchParams.toString(),
       stream,
       +contentLengthString,
@@ -431,13 +432,14 @@ v2Router.patch("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
 });
 
 v2Router.put("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
-  const { name } = req.params;
+  const { name, uuid } = req.params;
   const { digest } = req.query;
 
   const url = new URL(req.url);
   const [res, err] = await wrap<FinishedUploadObject | RegistryError, Error>(
     env.REGISTRY_CLIENT.finishUpload(
       name,
+      uuid,
       url.pathname + "?" + url.searchParams.toString(),
       digest! as string,
       req.body ?? undefined,

--- a/src/user.ts
+++ b/src/user.ts
@@ -3,7 +3,7 @@ import { Authenticator, AuthenticatorCheckCredentialsResponse, stripUsernamePass
 export const SHA256_PREFIX = "sha256";
 export const SHA256_PREFIX_LEN = SHA256_PREFIX.length + 1; // add ":"
 
-export function hexToDigest(sha256: ArrayBuffer, prefix: string = SHA256_PREFIX+':') {
+export function hexToDigest(sha256: ArrayBuffer, prefix: string = SHA256_PREFIX + ":") {
   const digest = [...new Uint8Array(sha256)].map((b) => b.toString(16).padStart(2, "0")).join("");
 
   return `${prefix}${digest}`;
@@ -15,7 +15,7 @@ function stringToArrayBuffer(s: string): ArrayBuffer {
   return arr;
 }
 
-export async function getSHA256(data: string, prefix: string = SHA256_PREFIX+':'): Promise<string> {
+export async function getSHA256(data: string, prefix: string = SHA256_PREFIX + ":"): Promise<string> {
   const sha256 = new crypto.DigestStream("SHA-256");
   const w = sha256.getWriter();
   const encoder = new TextEncoder();

--- a/src/user.ts
+++ b/src/user.ts
@@ -3,10 +3,10 @@ import { Authenticator, AuthenticatorCheckCredentialsResponse, stripUsernamePass
 export const SHA256_PREFIX = "sha256";
 export const SHA256_PREFIX_LEN = SHA256_PREFIX.length + 1; // add ":"
 
-export function hexToDigest(sha256: ArrayBuffer) {
+export function hexToDigest(sha256: ArrayBuffer, prefix: string = SHA256_PREFIX+':') {
   const digest = [...new Uint8Array(sha256)].map((b) => b.toString(16).padStart(2, "0")).join("");
 
-  return `${SHA256_PREFIX}:${digest}`;
+  return `${prefix}${digest}`;
 }
 
 function stringToArrayBuffer(s: string): ArrayBuffer {
@@ -15,14 +15,14 @@ function stringToArrayBuffer(s: string): ArrayBuffer {
   return arr;
 }
 
-export async function getSHA256(data: string): Promise<string> {
+export async function getSHA256(data: string, prefix: string = SHA256_PREFIX+':'): Promise<string> {
   const sha256 = new crypto.DigestStream("SHA-256");
   const w = sha256.getWriter();
   const encoder = new TextEncoder();
   const arr = encoder.encode(data);
   w.write(arr);
   w.close();
-  return hexToDigest(await sha256.digest);
+  return hexToDigest(await sha256.digest, prefix);
 }
 
 export class UserAuthenticator implements Authenticator {


### PR DESCRIPTION
This PR fixes the issue of the evergrowing state url parameter for chunked uploads, on very large layers state jwt could exceed 16k limit for worker URL resulting in failed uploads.
This fix replaces state with stateHash to make sure the upload state is consistently in order across chunk sequence (relying on the docker spec requirement of chunk uploads being sequential)