### PR TITLE
nit: skip upload state JWT verification as it now it lives in R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,7 @@ r2_buckets = [
 ]
 ```
 
-2. Setup the JWT_STATE_SECRET secret binding
-
-```bash
-$ node -p 'crypto.randomUUID()' | wrangler --env production secret put JWT_STATE_SECRET
-```
-
-3. Deploy your image registry
+2. Deploy your image registry
 
 ```bash
 $ wrangler deploy --env production

--- a/index.test.ts
+++ b/index.test.ts
@@ -26,7 +26,6 @@ function usernamePasswordToAuth(username: string, password: string): string {
 }
 
 const bindings = getMiniflareBindings() as Env;
-bindings.JWT_STATE_SECRET = "hello-world";
 async function fetchUnauth(r: Request): Promise<Response> {
   const res = await v2Router.handle(r, bindings);
   return res as Response;
@@ -354,7 +353,6 @@ describe("http client", () => {
 
   test("test manifest exists", async () => {
     envBindings = { ...bindings };
-    envBindings.JWT_STATE_SECRET = "hello";
     envBindings.JWT_REGISTRY_TOKENS_PUBLIC_KEY = "";
     envBindings.PASSWORD = "123456";
     envBindings.USERNAME = "v1";

--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,6 @@ export interface Env {
   JWT_REGISTRY_TOKENS_PUBLIC_KEY?: string;
   USERNAME?: string;
   PASSWORD?: string;
-  JWT_STATE_SECRET: string;
   PUSH_COMPATIBILITY_MODE?: PushCompatibilityMode;
   REGISTRIES_JSON?: string; // should be in the format of RegistryConfiguration[];
   REGISTRY_CLIENT: Registry;
@@ -84,13 +83,6 @@ const ensureConfig = (env: Env): boolean => {
   if (!env.REGISTRY) {
     console.error(
       "env.REGISTRY is not setup. Please setup an R2 bucket and add the binding in wrangler.toml. Try 'wrangler --env production r2 bucket create r2-registry'",
-    );
-    return false;
-  }
-
-  if (!env.JWT_STATE_SECRET) {
-    console.error(
-      `env.JWT_STATE_SECRET is not set. Please setup this secret using wrnagler. Try 'echo \`node -e "console.log(crypto.randomUUID())"\` | wrangler --env production secret put JWT_STATE_SECRET'`,
     );
     return false;
   }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,10 +15,6 @@ r2_buckets = [
 JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
 
 # Secrets:
-# JWT_STATE_SECRET
-# echo `node -e "console.log(crypto.randomUUID())"` | wrangler secret put JWT_STATE_SECRET
-
-# Optional Secrets
 # USERNAME/PASSWORD if you want username/password based auth
 
 
@@ -27,7 +23,6 @@ JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
 r2_buckets = [{ binding = "REGISTRY", bucket_name = "r2-image-registry-dev" }]
 [env.dev.vars]
 # REGISTRIES_JSON = "[{ \"registry\": \"http://localhost:9999\", \"password_env\": \"PASSWORD\", \"username\": \"hello\" }]"
-JWT_STATE_SECRET = "HELLO"
 USERNAME = "hello"
 PASSWORD = "world"
 # The necessary secrets are:


### PR DESCRIPTION
The main reasoning is that we are preparing to remove the JWT encoding of the upload state. Using the R2 object that contains the state string is enough.