### PR TITLE
contributing: update guide for non-Linux

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 ## Running the registry
 
-
 Running the registry is done via `wrangler dev`
 
 ```bash
@@ -13,9 +12,19 @@ You can `docker login` locally for running a push
 $ docker login localhost:8787 # Or the URL that your worker is listening in
 ```
 
+Note: If you are running Docker desktop in MacOS/Windows, you should add the following to the docker daemon configuration:
+
+```json
+{
+  "insecure-registries": ["host.docker.internal:8787"]
+}
+```
+
 By default in a local environment, the registry uses USERNAME=hello and PASSWORD=world. See `wrangler.toml` for more details.
 
 Tag any image that you have locally and push it:
+
+This allows you to instead of using localhost, you are able to use host.docker.internal to access local registries.
 
 ```bash
 $ docker tag my-image:local docker tag localhost:8787/my-image:local && docker push localhost:8787/my-image:local
@@ -23,7 +32,7 @@ $ docker tag my-image:local docker tag localhost:8787/my-image:local && docker p
 
 ## Testing
 
-Test the registry with unit tests by running `vitest` with `miniflare 2`. 
+Test the registry with unit tests by running `vitest` with `miniflare 3`.
 
 ```bash
 $ pnpm test


### PR DESCRIPTION
Since we started validating manifests, we are starting to reject schemaVersion: 1. Seems like docker still likes to push these kind of manifests, so accept it anyway.