### PR TITLE
fix: schemaVersion 1 should be supported by the registry

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,31 +1,45 @@
 import { z } from "zod";
 
 // https://github.com/opencontainers/image-spec/blob/main/manifest.md
-export const manifestSchema = z.object({
-  schemaVersion: z.literal(2),
-  artifactType: z.string().optional(),
-  // to maintain retrocompatibility of the registry, let's not assume mediaTypes
-  mediaType: z.string(),
-  config: z.object({
+export const manifestSchema = z
+  .object({
+    schemaVersion: z.literal(2),
+    artifactType: z.string().optional(),
+    // to maintain retrocompatibility of the registry, let's not assume mediaTypes
     mediaType: z.string(),
-    digest: z.string(),
-    size: z.number().int(),
-  }),
-  layers: z.array(
-    z.object({
-      size: z.number().int(),
+    config: z.object({
       mediaType: z.string(),
       digest: z.string(),
+      size: z.number().int(),
     }),
-  ),
-  annotations: z.record(z.string()).optional(),
-  subject: z
-    .object({
-      mediaType: z.string(),
-      digest: z.string(),
-      size: z.number().int(),
-    })
-    .optional(),
-});
+    layers: z.array(
+      z.object({
+        size: z.number().int(),
+        mediaType: z.string(),
+        digest: z.string(),
+      }),
+    ),
+    annotations: z.record(z.string()).optional(),
+    subject: z
+      .object({
+        mediaType: z.string(),
+        digest: z.string(),
+        size: z.number().int(),
+      })
+      .optional(),
+  })
+  .or(
+    z
+      .object({
+        schemaVersion: z.literal(1),
+        fsLayers: z.array(z.object({ blobSum: z.string() })),
+        architecture: z.string().optional(),
+        tag: z.string().optional(),
+        name: z.string().optional(),
+        history: z.array(z.unknown()).optional(),
+        signatures: z.array(z.unknown()).optional(),
+      })
+      .and(z.record(z.unknown())),
+  );
 
 export type ManifestSchema = z.infer<typeof manifestSchema>;

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -40,6 +40,26 @@ export const manifestSchema = z
         signatures: z.array(z.unknown()).optional(),
       })
       .and(z.record(z.unknown())),
+  )
+  .or(
+    z.object({
+      schemaVersion: z.literal(2),
+      mediaType: z.string(),
+      manifests: z.array(
+        z.object({
+          mediaType: z.string(),
+          platform: z.object({
+            "architecture": z.string(),
+            "os": z.string(),
+            "os.version": z.string().optional(),
+            "variant": z.string().optional(),
+            "features": z.array(z.string()).optional(),
+          }),
+          digest: z.string(),
+          size: z.number().int(),
+        }),
+      ),
+    }),
   );
 
 export type ManifestSchema = z.infer<typeof manifestSchema>;

--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -196,9 +196,15 @@ export class GarbageCollector {
       }
 
       const manifestData = (await manifest.json()) as ManifestSchema;
-      manifestData.layers.forEach((layer) => {
-        referencedBlobs.add(layer.digest);
-      });
+      if (manifestData.schemaVersion === 1) {
+        manifestData.fsLayers.forEach((layer) => {
+          referencedBlobs.add(layer.blobSum);
+        });
+      } else {
+        manifestData.layers.forEach((layer) => {
+          referencedBlobs.add(layer.digest);
+        });
+      }
 
       return true;
     });

--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -196,6 +196,11 @@ export class GarbageCollector {
       }
 
       const manifestData = (await manifest.json()) as ManifestSchema;
+      // TODO: garbage collect manifests.
+      if ("manifests" in manifestData) {
+        return true;
+      }
+
       if (manifestData.schemaVersion === 1) {
         manifestData.fsLayers.forEach((layer) => {
           referencedBlobs.add(layer.blobSum);

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -260,12 +260,15 @@ export class R2Registry implements Registry {
   }
 
   async verifyManifest(name: string, manifest: ManifestSchema) {
-    const layers = [...manifest.layers, manifest.config];
+    const layers: string[] =
+      manifest.schemaVersion === 1
+        ? manifest.fsLayers.map((layer) => layer.blobSum)
+        : [...manifest.layers.map((layer) => layer.digest), manifest.config.digest];
     for (const key of layers) {
-      const res = await this.env.REGISTRY.head(`${name}/blobs/${key.digest}`);
+      const res = await this.env.REGISTRY.head(`${name}/blobs/${key}`);
       if (res === null) {
         console.error(`Digest ${key} doesn't exist`);
-        return new ManifestError("BLOB_UNKNOWN", `unknown blob ${key.digest}`);
+        return new ManifestError("BLOB_UNKNOWN", `unknown blob ${key}`);
       }
     }
 

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -260,6 +260,19 @@ export class R2Registry implements Registry {
   }
 
   async verifyManifest(name: string, manifest: ManifestSchema) {
+    if (manifest.schemaVersion === 2 && "manifests" in manifest) {
+      for (const manifestElement of manifest.manifests) {
+        const key = manifestElement.digest;
+        const res = await this.env.REGISTRY.head(`${name}/manifests/${key}`);
+        if (res === null) {
+          console.error(`Manifest with digest ${key} doesn't exist`);
+          return new ManifestError("BLOB_UNKNOWN", `unknown manifest ${key}`);
+        }
+      }
+
+      return null;
+    }
+
     const layers: string[] =
       manifest.schemaVersion === 1
         ? manifest.fsLayers.map((layer) => layer.blobSum)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -31,7 +31,10 @@ async function generateManifest(name: string, schemaVersion: 1 | 2 = 2): Promise
       }
     : {
         schemaVersion,
-        layers: [{ size: data.length, digest: sha256, mediaType: "shouldbeanything" }],
+        layers: [
+          { size: data.length, digest: sha256, mediaType: "shouldbeanything" },
+          { size: data.length, digest: sha256, mediaType: "shouldbeanything" },
+        ],
         config: { size: data.length, digest: sha256, mediaType: "configmediatypeshouldntbechecked" },
         mediaType: "shouldalsobeanythingforretrocompatibility",
       };
@@ -495,7 +498,7 @@ describe("push and catalog", () => {
       "hello",
       "hello-2",
       "latest",
-      "sha256:e8f14a06f5e206931feb6761a6022231c98917edeb9d7f44c88f075113656374",
+      "sha256:a8a29b609fa044cf3ee9a79b57a6fbfb59039c3e9c4f38a57ecb76238bf0dec6",
     ]);
 
     const repositoryBuildUp: string[] = [];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -12,7 +12,7 @@ import { limit } from "../src/chunk";
 import worker from "../index";
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 
-async function generateManifest(name: string): Promise<ManifestSchema> {
+async function generateManifest(name: string, schemaVersion: 1 | 2 = 2): Promise<ManifestSchema> {
   const data = "bla";
   const sha256 = await getSHA256(data);
   const res = await fetch(createRequest("POST", `/v2/${name}/blobs/uploads/`, null, {}));
@@ -23,12 +23,18 @@ async function generateManifest(name: string): Promise<ManifestSchema> {
   expect(res2.ok).toBeTruthy();
   const last = await fetch(createRequest("PUT", res2.headers.get("location")! + "&digest=" + sha256, null, {}));
   expect(last.ok).toBeTruthy();
-  return {
-    schemaVersion: 2,
-    layers: [{ size: data.length, digest: sha256, mediaType: "shouldbeanything" }],
-    config: { size: data.length, digest: sha256, mediaType: "configmediatypeshouldntbechecked" },
-    mediaType: "shouldalsobeanythingforretrocompatibility",
-  };
+  return schemaVersion === 1
+    ? {
+        schemaVersion,
+        fsLayers: [{ blobSum: sha256 }],
+        architecture: "amd64",
+      }
+    : {
+        schemaVersion,
+        layers: [{ size: data.length, digest: sha256, mediaType: "shouldbeanything" }],
+        config: { size: data.length, digest: sha256, mediaType: "configmediatypeshouldntbechecked" },
+        mediaType: "shouldalsobeanythingforretrocompatibility",
+      };
 }
 
 function createRequest(method: string, path: string, body: ReadableStream | null, headers = {}) {
@@ -490,6 +496,49 @@ describe("push and catalog", () => {
       "hello-2",
       "latest",
       "sha256:e8f14a06f5e206931feb6761a6022231c98917edeb9d7f44c88f075113656374",
+    ]);
+
+    const repositoryBuildUp: string[] = [];
+    let currentPath = "/v2/_catalog?n=1";
+    for (let i = 0; i < 3; i++) {
+      const response = await fetch(createRequest("GET", currentPath, null));
+      expect(response.ok).toBeTruthy();
+      const body = (await response.json()) as { repositories: string[] };
+      if (body.repositories.length === 0) {
+        break;
+      }
+      expect(body.repositories).toHaveLength(1);
+
+      repositoryBuildUp.push(...body.repositories);
+      const url = new URL(response.headers.get("Link")!.split(";")[0].trim());
+      currentPath = url.pathname + url.search;
+    }
+
+    expect(repositoryBuildUp).toEqual(expectedRepositories);
+  });
+
+  test("(v1) push and then use the catalog", async () => {
+    await createManifest("hello-world-main", await generateManifest("hello-world-main", 1), "hello");
+    await createManifest("hello-world-main", await generateManifest("hello-world-main", 1), "latest");
+    await createManifest("hello-world-main", await generateManifest("hello-world-main", 1), "hello-2");
+    await createManifest("hello", await generateManifest("hello", 1), "hello");
+    await createManifest("hello/hello", await generateManifest("hello/hello", 1), "hello");
+
+    const response = await fetch(createRequest("GET", "/v2/_catalog", null));
+    expect(response.ok).toBeTruthy();
+    const body = (await response.json()) as { repositories: string[] };
+    expect(body).toEqual({
+      repositories: ["hello-world-main", "hello/hello", "hello"],
+    });
+    const expectedRepositories = body.repositories;
+    const tagsRes = await fetch(createRequest("GET", `/v2/hello-world-main/tags/list?n=1000`, null));
+    const tags = (await tagsRes.json()) as TagsList;
+    expect(tags.name).toEqual("hello-world-main");
+    expect(tags.tags).toEqual([
+      "hello",
+      "hello-2",
+      "latest",
+      "sha256:a70525d2dd357c6ece8d9e0a5a232e34ca3bbceaa1584d8929cdbbfc81238210",
     ]);
 
     const repositoryBuildUp: string[] = [];


### PR DESCRIPTION
Since we started validating manifests, we are starting to reject schemaVersion: 1. Seems like docker still likes to push these kind of manifests, so accept it anyway.
Fixes #52 