### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An open-source R2 registry",
   "main": "index.ts",
   "scripts": {
-    "deploy": "wrangler publish",
+    "deploy": "wrangler deploy",
     "dev:miniflare": "cross-env NODE_ENV=development wrangler --env dev dev --port 9999 --live-reload",
     "typecheck": "tsc",
     "test": "vitest --config test/vitest.config.ts run"


### PR DESCRIPTION
This PR update the command `deploy` to use `wrangler deploy` instead of `wrangler publish` since `wrangler publish` is deprecated and will be removed in the next major version.