### PR TITLE
Check capabilities in requests for basic auth users and added pull-only credentials

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,8 @@ export interface Env {
   JWT_REGISTRY_TOKENS_PUBLIC_KEY?: string;
   USERNAME?: string;
   PASSWORD?: string;
+  READONLY_USERNAME?: string;
+  READONLY_PASSWORD?: string;
   PUSH_COMPATIBILITY_MODE?: PushCompatibilityMode;
   REGISTRIES_JSON?: string; // should be in the format of RegistryConfiguration[];
   REGISTRY_CLIENT: Registry;

--- a/src/authentication-method.ts
+++ b/src/authentication-method.ts
@@ -1,12 +1,21 @@
 import { Env } from "..";
 import { newRegistryTokens } from "./token";
 import { UserAuthenticator } from "./user";
+import type { AuthenticatorCredentials } from "./user";
 
 export async function authenticationMethodFromEnv(env: Env) {
   if (env.JWT_REGISTRY_TOKENS_PUBLIC_KEY) {
     return await newRegistryTokens(env.JWT_REGISTRY_TOKENS_PUBLIC_KEY);
   } else if (env.USERNAME && env.PASSWORD) {
-    return new UserAuthenticator(env.USERNAME, env.PASSWORD);
+    const credentials: AuthenticatorCredentials[] = [
+      { username: env.USERNAME, password: env.PASSWORD, capabilities: ["pull", "push"] }
+    ];
+
+    if (env.READONLY_USERNAME && env.READONLY_PASSWORD) {
+      credentials.push({ username: env.READONLY_USERNAME, password: env.READONLY_PASSWORD, capabilities: ["pull"] });
+    }
+
+    return new UserAuthenticator(credentials);
   }
 
   console.error("Either env.JWT_REGISTRY_TOKENS_PUBLIC_KEY must be set or both env.USERNAME, env.PASSWORD must be set.");

--- a/src/token.ts
+++ b/src/token.ts
@@ -74,7 +74,7 @@ export class RegistryTokens implements Authenticator {
     return token;
   }
 
-  checkIfV2OnlyPath(request: Request): boolean {
+  static checkIfV2OnlyPath(request: Request): boolean {
     return request.url.endsWith("/v2/");
   }
 
@@ -95,7 +95,7 @@ export class RegistryTokens implements Authenticator {
       // the JWT signature is valid, decode it now
       const decoded = jwt.decode(token);
       const payload = decoded.payload as RegistryAuthProtocolTokenPayload;
-      return this.verifyPayload(request, payload);
+      return RegistryTokens.verifyPayload(request, payload);
     } catch (error) {
       // If the verification fails (e.g., due to token expiration or signature mismatch),
       // jwt.verify() will throw an error which we can catch here.
@@ -107,7 +107,7 @@ export class RegistryTokens implements Authenticator {
     }
   }
 
-  verifyPayload(request: Request, payload: RegistryAuthProtocolTokenPayload) {
+  static verifyPayload(request: Request, payload: RegistryAuthProtocolTokenPayload) {
     // Check if token has expired
     const now = Math.floor(Date.now() / 1000);
     if (payload.exp && now >= payload.exp) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -268,24 +268,21 @@ describe("v2 manifests", () => {
 
 describe("tokens", async () => {
   test("auth payload push on /v2", async () => {
-    const auth = new RegistryTokens({} as JsonWebKey);
-    const { verified } = auth.verifyPayload(createRequest("GET", "/v2/", null), {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("GET", "/v2/", null), {
       capabilities: ["push"],
     } as RegistryAuthProtocolTokenPayload);
     expect(verified).toBeTruthy();
   });
 
   test("auth payload pull on /v2", async () => {
-    const auth = new RegistryTokens({} as JsonWebKey);
-    const { verified } = auth.verifyPayload(createRequest("GET", "/v2/", null), {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("GET", "/v2/", null), {
       capabilities: ["pull"],
     } as RegistryAuthProtocolTokenPayload);
     expect(verified).toBeTruthy();
   });
 
   test("auth payload push on /v2/whatever with HEAD", async () => {
-    const auth = new RegistryTokens({} as JsonWebKey);
-    const { verified } = auth.verifyPayload(createRequest("HEAD", "/v2/whatever", null), {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("HEAD", "/v2/whatever", null), {
       capabilities: ["push"],
     } as RegistryAuthProtocolTokenPayload);
     expect(verified).toBeTruthy();
@@ -293,8 +290,7 @@ describe("tokens", async () => {
 
   test("auth payload push on /v2/whatever with mutations", async () => {
     for (const mutationMethod of ["PATCH", "POST", "DELETE"]) {
-      const auth = new RegistryTokens({} as JsonWebKey);
-      const { verified } = auth.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
+      const { verified } = RegistryTokens.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
         capabilities: ["push"],
       } as RegistryAuthProtocolTokenPayload);
       expect(verified).toBeTruthy();
@@ -303,8 +299,7 @@ describe("tokens", async () => {
 
   test("auth payload pull on /v2/whatever with mutations", async () => {
     for (const mutationMethod of ["PATCH", "POST", "DELETE"]) {
-      const auth = new RegistryTokens({} as JsonWebKey);
-      const { verified } = auth.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
+      const { verified } = RegistryTokens.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
         capabilities: ["pull"],
       } as RegistryAuthProtocolTokenPayload);
       expect(verified).toBeFalsy();
@@ -313,8 +308,7 @@ describe("tokens", async () => {
 
   test("auth payload push/pull on /v2/whatever with mutations", async () => {
     for (const mutationMethod of ["PATCH", "POST", "DELETE"]) {
-      const auth = new RegistryTokens({} as JsonWebKey);
-      const { verified } = auth.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
+      const { verified } = RegistryTokens.verifyPayload(createRequest(mutationMethod, "/v2/whatever", null), {
         capabilities: ["pull", "push"],
       } as RegistryAuthProtocolTokenPayload);
       expect(verified).toBeTruthy();
@@ -322,16 +316,14 @@ describe("tokens", async () => {
   });
 
   test("auth payload push on GET", async () => {
-    const auth = new RegistryTokens({} as JsonWebKey);
-    const { verified } = auth.verifyPayload(createRequest("GET", "/v2/whatever", null), {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("GET", "/v2/whatever", null), {
       capabilities: ["push"],
     } as RegistryAuthProtocolTokenPayload);
     expect(verified).toBeFalsy();
   });
 
   test("auth payload push/pull on GET", async () => {
-    const auth = new RegistryTokens({} as JsonWebKey);
-    const { verified } = auth.verifyPayload(createRequest("GET", "/v2/whatever", null), {
+    const { verified } = RegistryTokens.verifyPayload(createRequest("GET", "/v2/whatever", null), {
       capabilities: ["push", "pull"],
     } as RegistryAuthProtocolTokenPayload);
     expect(verified).toBeTruthy();

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -15,7 +15,7 @@ r2_buckets = [
 JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
 
 # Secrets:
-# USERNAME/PASSWORD if you want username/password based auth
+# USERNAME/PASSWORD/READONLY_USERNAME/READONLY_PASSWORD if you want username/password based auth
 
 
 ## Dev - For local dev using `npx wrangler dev`
@@ -25,6 +25,8 @@ r2_buckets = [{ binding = "REGISTRY", bucket_name = "r2-image-registry-dev" }]
 # REGISTRIES_JSON = "[{ \"registry\": \"http://localhost:9999\", \"password_env\": \"PASSWORD\", \"username\": \"hello\" }]"
 USERNAME = "hello"
 PASSWORD = "world"
+# READONLY_USERNAME = "readonly"
+# READONLY_PASSWORD = "readonly"
 # The necessary secrets are:
 # Setup those secrets on .dev.vars in the root of the project
 #


### PR DESCRIPTION
This a provisional implementation for #38.

While I've only tried with the `READONLY_USERNAME` and `READONLY_PASSWORD`, the passing of the capabilities should also work for the JWT tokens which have the capabilities in them.

Since JS/TS is not my world, please forgive me simple mistakes you could find.