### PR TITLE
Fix blob upload verify hash bypass

### DIFF
--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -120,7 +120,7 @@ export async function getUploadState(
     throw new InternalError();
   }
 
-  if (!verifyHash && stateStrHash !== verifyHash) {
+  if (verifyHash !== undefined && stateStrHash !== verifyHash) {
     return new RangeError(stateStrHash, stateObject);
   }
 

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -719,6 +719,7 @@ export class R2Registry implements Registry {
 
     const upload = this.env.REGISTRY.resumeMultipartUpload(state.registryUploadId, state.uploadId);
     await upload.abort();
+    await this.env.REGISTRY.delete(getRegistryUploadsPath(state));
     return true;
   }
 


### PR DESCRIPTION
Currently the `verifyHash` is checked if the string is not empty but in some cases, `undefined` is supplied to the function to bypass the hash verification but `!undefined === true` so an error is raise.
This PR change the check to explicitly detect the undefined value and continue the execution.

This change fix the issue https://github.com/cloudflare/serverless-registry/issues/86:
```
[wrangler:inf] DELETE /v2/image-b/blobs/uploads/7b51c49f-58c2-4864-8d86-ba5014f5333a 204 No Content (43ms)
```

This PR also remove the temporary upload file from the R2 bucket after the upload abort.