### PR TITLE
Add content-type JSON header to /v2/_catalog route

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -43,6 +43,7 @@ v2Router.get("/_catalog", async (req, env: Env) => {
     {
       headers: {
         Link: `${url.protocol}//${url.hostname}${url.pathname}?n=${n ?? 1000}&last=${response.cursor ?? ""}; rel=next`,
+        "Content-Type": "application/json",
       },
     },
   );


### PR DESCRIPTION
The Content-Type JSON header was missing on the `/v2/_catalog` route.