### PR TITLE
Removing SHA256 manifests from the tag listing

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -329,7 +329,7 @@ v2Router.delete("/:name+/blobs/uploads/:id", async (req, env: Env) => {
 
 // this is the first thing that the client asks for in an upload
 v2Router.post("/:name+/blobs/uploads/", async (req, env: Env) => {
-   const { name } = req.params;
+  const { name } = req.params;
   const [uploadObject, err] = await wrap<UploadObject | RegistryError, Error>(env.REGISTRY_CLIENT.startUpload(name));
 
   if (err) {
@@ -534,7 +534,7 @@ v2Router.get("/:name+/tags/list", async (req, env: Env) => {
     startAfter: last ? `${name}/manifests/${last}` : undefined,
   });
   // Filter out sha256 manifest
-  let manifest_tags = tags.objects.filter( tag => !tag.key.startsWith(`${name}/manifests/sha256:`))
+  let manifest_tags = tags.objects.filter((tag) => !tag.key.startsWith(`${name}/manifests/sha256:`));
   // If results are truncated and the manifest filter removed some result, extend the search to reach the n number of results expected by the client
   while (tags.objects.length > 0 && tags.truncated && manifest_tags.length !== n) {
     tags = await env.REGISTRY.list({
@@ -543,19 +543,21 @@ v2Router.get("/:name+/tags/list", async (req, env: Env) => {
       cursor: tags.cursor,
     });
     // Filter out sha256 manifest
-    manifest_tags = manifest_tags.concat(tags.objects.filter( tag => !tag.key.startsWith(`${name}/manifests/sha256:`)))
+    manifest_tags = manifest_tags.concat(
+      tags.objects.filter((tag) => !tag.key.startsWith(`${name}/manifests/sha256:`)),
+    );
   }
 
   const keys = manifest_tags.map((object) => object.key.split("/").pop()!);
   const url = new URL(req.url);
   url.searchParams.set("n", `${n}`);
   url.searchParams.set("last", keys.length ? keys[keys.length - 1] : "");
-  const response_headers: {"Content-Type":string, "Link"?:string} = {
-    "Content-Type": "application/json"
-  }
+  const response_headers: { "Content-Type": string; "Link"?: string } = {
+    "Content-Type": "application/json",
+  };
   // Only supply a next link if the previous result is truncated
   if (tags.truncated) {
-    response_headers.Link = `${url.toString()}; rel=next`
+    response_headers.Link = `${url.toString()}; rel=next`;
   }
   return new Response(
     JSON.stringify({

--- a/src/router.ts
+++ b/src/router.ts
@@ -534,30 +534,30 @@ v2Router.get("/:name+/tags/list", async (req, env: Env) => {
     startAfter: last ? `${name}/manifests/${last}` : undefined,
   });
   // Filter out sha256 manifest
-  let manifest_tags = tags.objects.filter((tag) => !tag.key.startsWith(`${name}/manifests/sha256:`));
+  let manifestTags = tags.objects.filter((tag) => !tag.key.startsWith(`${name}/manifests/sha256:`));
   // If results are truncated and the manifest filter removed some result, extend the search to reach the n number of results expected by the client
-  while (tags.objects.length > 0 && tags.truncated && manifest_tags.length !== n) {
+  while (tags.objects.length > 0 && tags.truncated && manifestTags.length !== n) {
     tags = await env.REGISTRY.list({
       prefix: `${name}/manifests`,
-      limit: n - manifest_tags.length,
+      limit: n - manifestTags.length,
       cursor: tags.cursor,
     });
     // Filter out sha256 manifest
-    manifest_tags = manifest_tags.concat(
+    manifestTags = manifestTags.concat(
       tags.objects.filter((tag) => !tag.key.startsWith(`${name}/manifests/sha256:`)),
     );
   }
 
-  const keys = manifest_tags.map((object) => object.key.split("/").pop()!);
+  const keys = manifestTags.map((object) => object.key.split("/").pop()!);
   const url = new URL(req.url);
   url.searchParams.set("n", `${n}`);
   url.searchParams.set("last", keys.length ? keys[keys.length - 1] : "");
-  const response_headers: { "Content-Type": string; "Link"?: string } = {
+  const responseHeaders: { "Content-Type": string; "Link"?: string } = {
     "Content-Type": "application/json",
   };
   // Only supply a next link if the previous result is truncated
   if (tags.truncated) {
-    response_headers.Link = `${url.toString()}; rel=next`;
+    responseHeaders.Link = `${url.toString()}; rel=next`;
   }
   return new Response(
     JSON.stringify({
@@ -566,7 +566,7 @@ v2Router.get("/:name+/tags/list", async (req, env: Env) => {
     }),
     {
       status: 200,
-      headers: response_headers,
+      headers: responseHeaders,
     },
   );
 });

--- a/src/router.ts
+++ b/src/router.ts
@@ -524,20 +524,39 @@ v2Router.get("/:name+/tags/list", async (req, env: Env) => {
 
   const { n: nStr = 50, last } = req.query;
   const n = +nStr;
-  if (isNaN(n)) {
+  if (isNaN(n) || n <= 0) {
     throw new ServerError("invalid 'n' parameter", 400);
   }
 
-  const tags = await env.REGISTRY.list({
+  let tags = await env.REGISTRY.list({
     prefix: `${name}/manifests`,
     limit: n,
     startAfter: last ? `${name}/manifests/${last}` : undefined,
   });
+  // Filter out sha256 manifest
+  let manifest_tags = tags.objects.filter( tag => !tag.key.startsWith(`${name}/manifests/sha256:`))
+  // If results are truncated and the manifest filter removed some result, extend the search to reach the n number of results expected by the client
+  while (tags.objects.length > 0 && tags.truncated && manifest_tags.length !== n) {
+    tags = await env.REGISTRY.list({
+      prefix: `${name}/manifests`,
+      limit: n - manifest_tags.length,
+      cursor: tags.cursor,
+    });
+    // Filter out sha256 manifest
+    manifest_tags = manifest_tags.concat(tags.objects.filter( tag => !tag.key.startsWith(`${name}/manifests/sha256:`)))
+  }
 
-  const keys = tags.objects.map((object) => object.key.split("/").pop()!);
+  const keys = manifest_tags.map((object) => object.key.split("/").pop()!);
   const url = new URL(req.url);
   url.searchParams.set("n", `${n}`);
   url.searchParams.set("last", keys.length ? keys[keys.length - 1] : "");
+  const response_headers: {"Content-Type":string, "Link"?:string} = {
+    "Content-Type": "application/json"
+  }
+  // Only supply a next link if the previous result is truncated
+  if (tags.truncated) {
+    response_headers.Link = `${url.toString()}; rel=next`
+  }
   return new Response(
     JSON.stringify({
       name,
@@ -545,10 +564,7 @@ v2Router.get("/:name+/tags/list", async (req, env: Env) => {
     }),
     {
       status: 200,
-      headers: {
-        "Content-Type": "application/json",
-        "Link": `${url.toString()}; rel=next`,
-      },
+      headers: response_headers,
     },
   );
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -242,7 +242,7 @@ describe("v2 manifests", () => {
 
   test("PUT then list tags with GET /v2/:name/tags/list", async () => {
     const { sha256 } = await createManifest("hello-world-list", await generateManifest("hello-world-list"), `hello`);
-    const expectedRes = ["hello", sha256];
+    const expectedRes = ["hello"];
     for (let i = 0; i < 50; i++) {
       expectedRes.push(`hello-${i}`);
     }
@@ -257,6 +257,7 @@ describe("v2 manifests", () => {
     const tags = (await tagsRes.json()) as TagsList;
     expect(tags.name).toEqual("hello-world-list");
     expect(tags.tags).toEqual(expectedRes);
+    expect(tags.tags).not.contain(sha256)
 
     const res = await fetch(createRequest("DELETE", `/v2/hello-world-list/manifests/${sha256}`, null));
     expect(res.ok).toBeTruthy();
@@ -514,8 +515,8 @@ describe("push and catalog", () => {
       "hello",
       "hello-2",
       "latest",
-      "sha256:a8a29b609fa044cf3ee9a79b57a6fbfb59039c3e9c4f38a57ecb76238bf0dec6",
     ]);
+    expect(tags.tags).not.contain("sha256:a8a29b609fa044cf3ee9a79b57a6fbfb59039c3e9c4f38a57ecb76238bf0dec6");
 
     const repositoryBuildUp: string[] = [];
     let currentPath = "/v2/_catalog?n=1";
@@ -557,8 +558,8 @@ describe("push and catalog", () => {
       "hello",
       "hello-2",
       "latest",
-      "sha256:a70525d2dd357c6ece8d9e0a5a232e34ca3bbceaa1584d8929cdbbfc81238210",
     ]);
+    expect(tags.tags).not.contain("sha256:a70525d2dd357c6ece8d9e0a5a232e34ca3bbceaa1584d8929cdbbfc81238210");
 
     const repositoryBuildUp: string[] = [];
     let currentPath = "/v2/_catalog?n=1";


### PR DESCRIPTION
Official Docker registry doesn't list raw SHA256 manifest (cf. https://docker-docs.uclv.cu/registry/spec/api/#listing-image-tags). Tested on `registry-1.docker.io`.
In the current version of the serverless-registry, tag listing return tags but also sha256:[...] manifests that should be excluded.

I didn't find a way to directly query R2 with a more advance filter to exclude the sha256 manifest.
Instead I had to add a filter to remove them and a loop to find more tags until the `n` number of result are reach.

Bonus:
- I've also added a condition to only accept `n > 0` to avoid any crash from the registry
- Now the `Link` for the next page is only supplied to the client if there is more result to fetch

