### PR TITLE
Handle unknown upload Id

### DIFF
--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -713,7 +713,9 @@ export class R2Registry implements Registry {
       return { response: new InternalError() };
     }
     if (hashedState === null || !hashedState.state) {
-      return { response: new InternalError() };
+      return {
+        response: new Response(null, { status: 404 }),
+      }
     }
     const state = hashedState.state;
 


### PR DESCRIPTION
When user supply an unknown upload id (or already removed) to the `cancelUpload` function, the registry now return a 404 error instead of 500.