### PR TITLE
Add suport for layer mounting + garbage collector refactor

### DIFF
--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -4,6 +4,7 @@
 
 import { ManifestSchema } from "../manifest";
 import { hexToDigest } from "../user";
+import {symlinkHeader} from "./r2";
 
 export type GarbageCollectionMode = "unreferenced" | "untagged";
 export type GCOptions = {
@@ -293,7 +294,7 @@ export class GarbageCollector {
         if (objectPath.startsWith(`${options.name}/`) || !objectPath.includes("/blobs/sha256:")) {
           return true;
         }
-        if (object.customMetadata && object.customMetadata["r2_symlink"] !== undefined) {
+        if (object.customMetadata && object.customMetadata[symlinkHeader] !== undefined) {
           // Find symlink target
           const manifest = await this.registry.get(object.key);
           // Skip if manifest not found

--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -295,15 +295,17 @@ export class GarbageCollector {
           return true;
         }
         if (object.customMetadata && object.customMetadata[symlinkHeader] !== undefined) {
-          // Find symlink target
-          const manifest = await this.registry.get(object.key);
-          // Skip if manifest not found
-          if (!manifest) return true;
-          // Get symlink target
-          const symlinkTarget = await manifest.text();
-          if (unreferencedBlobs.has(symlinkTarget)) {
+          // Check if the symlink target the current GC repository
+          if (object.customMetadata[symlinkHeader] !== options.name) return true;
+          // Get symlink blob to retrieve its target
+          const symlinkBlob = await this.registry.get(object.key);
+          // Skip if symlinkBlob not found
+          if (!symlinkBlob) return true;
+          // Get the path of the target blob from the symlink blob
+          const targetBlobPath = await symlinkBlob.text();
+          if (unreferencedBlobs.has(targetBlobPath)) {
             // This symlink target a layer that should be removed
-            unreferencedBlobs.delete(symlinkTarget);
+            unreferencedBlobs.delete(targetBlobPath);
           }
         }
         return unreferencedBlobs.size > 0;

--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -4,6 +4,7 @@
 
 import { ServerError } from "../errors";
 import { ManifestSchema } from "../manifest";
+import { hexToDigest } from "../user";
 
 export type GarbageCollectionMode = "unreferenced" | "untagged";
 export type GCOptions = {
@@ -147,7 +148,7 @@ export class GarbageCollector {
   }
 
   private async list(prefix: string, callback: (object: R2Object) => Promise<boolean>): Promise<boolean> {
-    const listed = await this.registry.list({ prefix });
+    const listed = await this.registry.list({ prefix: prefix, include: ["customMetadata"] });
     for (const object of listed.objects) {
       if ((await callback(object)) === false) {
         return false;
@@ -182,61 +183,140 @@ export class GarbageCollector {
 
   private async collectInner(options: GCOptions): Promise<boolean> {
     // We can run out of memory, this should be a bloom filter
-    let referencedBlobs = new Set<string>();
+    const manifestList: { [key: string]: Set<string> } = {};
     const mark = await this.getInsertionMark(options.name);
 
+    // List manifest from repo to be scanned
     await this.list(`${options.name}/manifests/`, async (manifestObject) => {
-      const tag = manifestObject.key.split("/").pop();
-      if (!tag || (options.mode === "untagged" && tag.startsWith("sha256:"))) {
-        return true;
+      const current_hash_file = hexToDigest(manifestObject.checksums.sha256!);
+      if (manifestList[current_hash_file] === undefined) {
+        manifestList[current_hash_file] = new Set<string>();
       }
-      const manifest = await this.registry.get(manifestObject.key);
-      if (!manifest) {
-        return true;
+      manifestList[current_hash_file].add(manifestObject.key);
+      return true;
+    });
+
+    // In untagged mode, search for manifest to delete
+    if (options.mode === "untagged") {
+      const manifestToRemove = new Set<string>();
+      const referencedManifests = new Set<string>();
+      // List tagged manifest to find manifest-list
+      for (const [_, manifests] of Object.entries(manifestList)) {
+        const tagged_manifest = [...manifests].filter((item) => !item.split("/").pop()?.startsWith("sha256:"));
+        for (const manifest_path of tagged_manifest) {
+          // Tagged manifest some, load manifest content
+          const manifest = await this.registry.get(manifest_path);
+          if (!manifest) {
+            continue;
+          }
+
+          const manifestData = (await manifest.json()) as ManifestSchema;
+          // Search for manifest list
+          if (manifestData.schemaVersion == 2 && "manifests" in manifestData) {
+            // Extract referenced manifests from manifest list
+            manifestData.manifests.forEach((manifest) => {
+              referencedManifests.add(manifest.digest);
+            });
+          }
+        }
       }
 
-      const manifestData = (await manifest.json()) as ManifestSchema;
-      // TODO: garbage collect manifests.
-      if ("manifests" in manifestData) {
-        return true;
+      for (const [key, manifests] of Object.entries(manifestList)) {
+        if (referencedManifests.has(key)) {
+          continue;
+        }
+        if (![...manifests].some((item) => !item.split("/").pop()?.startsWith("sha256:"))) {
+          // Add untagged manifest that should be removed
+          manifests.forEach((manifest) => {
+            manifestToRemove.add(manifest);
+          });
+          // Manifest to be removed shouldn't be parsed to search for referenced layers
+          delete manifestList[key];
+        }
       }
+
+      // Deleting untagged manifest
+      if (manifestToRemove.size > 0) {
+        if (!(await this.checkIfGCCanContinue(options.name, mark))) {
+          throw new Error("there is a manifest insertion going, the garbage collection shall stop");
+        }
+
+        // GC will deleted untagged manifest
+        await this.registry.delete(manifestToRemove.values().toArray());
+      }
+    }
+
+    const referencedBlobs = new Set<string>();
+    // From manifest, extract referenced layers
+    for (const [_, manifests] of Object.entries(manifestList)) {
+      // Select only one manifest per unique manifest
+      const manifest_path = manifests.values().next().value;
+      if (manifest_path === undefined) {
+        continue;
+      }
+      const manifest = await this.registry.get(manifest_path);
+      // Skip if manifest not found
+      if (!manifest) continue;
+
+      const manifestData = (await manifest.json()) as ManifestSchema;
 
       if (manifestData.schemaVersion === 1) {
         manifestData.fsLayers.forEach((layer) => {
           referencedBlobs.add(layer.blobSum);
         });
       } else {
+        // Skip manifest-list, they don't contain any layers references
+        if ("manifests" in manifestData) continue;
+        // Add referenced layers from current manifest
         manifestData.layers.forEach((layer) => {
           referencedBlobs.add(layer.digest);
         });
+        // Add referenced config blob from current manifest
+        referencedBlobs.add(manifestData.config.digest);
       }
+    }
 
-      return true;
-    });
-
-    let unreferencedKeys: string[] = [];
-    const deleteThreshold = 15;
+    const unreferencedBlobs = new Set<string>();
+    // List blobs to be removed
     await this.list(`${options.name}/blobs/`, async (object) => {
-      const hash = object.key.split("/").pop();
-      if (hash && !referencedBlobs.has(hash)) {
-        unreferencedKeys.push(object.key);
-        if (unreferencedKeys.length > deleteThreshold) {
-          if (!(await this.checkIfGCCanContinue(options.name, mark))) {
-            throw new ServerError("there is a manifest insertion going, the garbage collection shall stop");
-          }
-
-          await this.registry.delete(unreferencedKeys);
-          unreferencedKeys = [];
-        }
+      const blob_hash = object.key.split("/").pop();
+      if (blob_hash && !referencedBlobs.has(blob_hash)) {
+        unreferencedBlobs.add(object.key);
       }
       return true;
     });
-    if (unreferencedKeys.length > 0) {
+
+    // Check for symlink before removal
+    if (unreferencedBlobs.size >= 0) {
+      await this.list("", async (object) => {
+        const object_path = object.key;
+        // Skip non-blobs object and from any other repository (symlink only target cross repository blobs)
+        if (object_path.startsWith(`${options.name}/`) || !object_path.includes("/blobs/sha256:")) {
+          return true;
+        }
+        if (object.customMetadata && object.customMetadata["r2_symlink"] !== undefined) {
+          // Find symlink target
+          const manifest = await this.registry.get(object.key);
+          // Skip if manifest not found
+          if (!manifest) return true;
+          // Get symlink target
+          const symlink_target = await manifest.text();
+          if (unreferencedBlobs.has(symlink_target)) {
+            // This symlink target a layer that should be removed
+            unreferencedBlobs.delete(symlink_target);
+          }
+        }
+        return unreferencedBlobs.size > 0;
+      });
+    }
+
+    if (unreferencedBlobs.size > 0) {
       if (!(await this.checkIfGCCanContinue(options.name, mark))) {
         throw new Error("there is a manifest insertion going, the garbage collection shall stop");
       }
 
-      await this.registry.delete(unreferencedKeys);
+      // GC will delete unreferenced blobs
+      await this.registry.delete(unreferencedBlobs.values().toArray());
     }
 
     return true;

--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -2,7 +2,6 @@
 // Unreferenced will delete all blobs that are not referenced by any manifest.
 // Untagged will delete all blobs that are not referenced by any manifest and are not tagged.
 
-import { ServerError } from "../errors";
 import { ManifestSchema } from "../manifest";
 import { hexToDigest } from "../user";
 

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -456,6 +456,14 @@ export class RegistryHTTPClient implements Registry {
     }
   }
 
+  mountExistingLayer(
+    _sourceName: string,
+    _digest: string,
+    _destinationName: string,
+  ): Promise<RegistryError | FinishedUploadObject> {
+    throw new Error("unimplemented");
+  }
+
   putManifest(
     _namespace: string,
     _reference: string,

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -454,15 +454,15 @@ export class R2Registry implements Registry {
 
     // Handle R2 symlink
     if (res.customMetadata && "r2_symlink" in res.customMetadata) {
-      const layer_path = await res.text();
-      // Symlink detected! Will download layer from "layer_path"
-      const [link_name, link_digest] = layer_path.split("/blobs/");
-      if (link_name == name && link_digest == digest) {
+      const layerPath = await res.text();
+      // Symlink detected! Will download layer from "layerPath"
+      const [linkName, linkDigest] = layerPath.split("/blobs/");
+      if (linkName == name && linkDigest == digest) {
         return {
           response: new Response(JSON.stringify(BlobUnknownError), { status: 404 }),
         };
       }
-      return await this.env.REGISTRY_CLIENT.getLayer(link_name, link_digest);
+      return await this.env.REGISTRY_CLIENT.getLayer(linkName, linkDigest);
     }
 
     return {

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -114,11 +114,11 @@ export interface Registry {
   // gets the manifest by namespace + digest
   getManifest(namespace: string, digest: string): Promise<GetManifestResponse | RegistryError>;
 
-  // mount an existing layer from a repo image to another
+  // mount an existing layer from a repository to another
   mountExistingLayer(
-    source_name: string,
+    sourceName: string,
     digest: string,
-    destination_name: string,
+    destinationName: string,
   ): Promise<RegistryError | FinishedUploadObject>;
 
   // checks that a layer exists

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -114,6 +114,13 @@ export interface Registry {
   // gets the manifest by namespace + digest
   getManifest(namespace: string, digest: string): Promise<GetManifestResponse | RegistryError>;
 
+  // mount an existing layer from a repo image to another
+  mountExistingLayer(
+    source_name: string,
+    digest: string,
+    destination_name: string,
+  ): Promise<RegistryError | FinishedUploadObject>;
+
   // checks that a layer exists
   layerExists(namespace: string, digest: string): Promise<CheckLayerResponse | RegistryError>;
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,7 @@
     "experimentalDecorators": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers"],
+    "types": ["@cloudflare/workers-types/2023-07-01", "@cloudflare/vitest-pool-workers"],
     "resolveJsonModule": true,
     "allowJs": true,
     "noEmit": true,


### PR DESCRIPTION
Hello,

Here is a PR to add support for layer mounting operations (issue #85).

# Overview
I have chosen to create pseudo-symlink system with R2 file and customMetadata to link a blob file to an existing blob on any other repository inside the registry.
An R2 symlink will include a `customMetadata`: `X-Serverless-Registry-Symlink` as key and the name of the targeted repository in its value (to avoid parsing the repository name from the full path of the targeted blob). The content of this symlink file is the full path to the targeted blob as text.

# Changes

## Registry

- New `mountExistingLayer` method for creating a new blob as an R2 symlink targeting another existing blob in another repository (if it exists).
  - This method avoids recursive symlinks
  - A layer mount operation only needs to return the new layer's digest and location URL
- Downloading a blob (or layer) now automatically follows R2 symlink to the referenced blob.

## Router

When uploading a new blob, if the client successfully mounts a layer, the registry should reply with code 201. If there is any error during the layer mounting operation, it will automatically fallback to the classic layer uploading process with response code 202.

## Garbage collector

The garbage collector `collectInner` function has been refactored to address many changes, including some existing bugs and limitations:
- Config blobs were ignored and not considered as referenced and then removed by GC causing errors
- Manifest list was not supported, ignoring architecture-specific untagged manifests and referenced blobs
- The GC was unable to delete untagged manifests in untagged mode, only blobs
With the new refactored function, it can now:
- Manage layer and config blobs for manifest v1 and v2
- Support manifest-list references in both `unreferenced` and `untagged` mode
- Support manifest deletion in untagged mode
- Add security checks for unreferenced R2 symlinks 

### Limitation of the new method / design
- I didn't include the `deleteThreshold` / number of blobs to delete at once, I don't know if this limit is still needed or not.
- Because the R2 symlink directly targets another blob in another directory, we need to list all the blobs in each repository (except the current one) to check that there is no symlink reference to the blob before removal. This check can be quite demanding for large registry.
   - If it could be possible to update `customMetadata` of an existing R2 object with the Worker R2 API, we could update a referenced counter on each symlink target blob and skip this heavy step but as far as I know it doesn't seem possible at the moment. However, if it's planned / soon-to-be release feature, it should be added in this first implementation to avoid adding an upgrade task later on.

The garbage collector `list` function now includes `customMetadata` to detect R2 symlinks.
> This change requires updating the `tsconfig.base.json` file by adding a minimum compatibility date. I've added the most recent date `2023-07-01` but it can be replaced by any older one that has the `include` parameter.

## Tests

To check the new features, I've added several tests.

~I'm also waiting for PR #89 to be merged as it'll introduce some test changes that will cause a conflict with this PR.~
Updated !

### Updating existing tests

- The `generateManifest` function allow to generate a simple v1 or v2 manifest and upload referenced blobs to a repository. 
This function had several problems:
  - blob data was hardcoded, so several images had the same blob digest, wich introduced unrealistic results
  - the layer blob and config blob were the same, missing the bug in the old garbage collector that deleted it while it was still in use.
The new version of this function generates random layer data and a unique config blob for each manifest, allowing different bugs to be detected. This change has introduced the need to update several tests to handle the new number of unique blobs.
- The `v2 manifests`/`PUT then list tags with GET /v2/:name/tags/list` test had to be reduced down from 50 images to 40 as it introduced some vitest instability, sometimes it works and sometime I get a `Network error` without any change or reason...
- Added blob count check on some tests

### Generic methods

- Added a new `generateManifestList` method to generate a manifest-list v2 from 2 manifests for AMD and ARM architectures.
- Added a new `getLayersFromManifest` method to extract every blob referenced by a given v1 or v2 manifest.
- Added a new `mountLayersFromManifest` method to mount every blob of a manifest from one repository to another.
- Added a new `createManifestList` method to generate two manifest and a manifest-list and upload all three to a repository with or without a tag.
- Added a new `runGarbageCollector` method to run the garbage collector on a given repository in a given mode (unreferenced, untagged or both).

### New tests

#### v2 manifest
Added a new test with recursive layers mounting of a simple image manifest

#### v2 manifest-list
Added a new tests to upload manifest-list images with or without layer mounting 

#### garbage collector
Added a few tests to check that the garbage collector deletes blobs and manifests as required, no more and no less.
- Test GC with single arch images
  - no action required
  - in untagged mode
  - in unreferenced blobs
- Test GC with mutli-arch / manifest-list images
  - no action required
  - in untagged mode
  - in unreferenced blobs
- Test GC with mutli-arch / manifest-list image including R2 symlink references
  - no action required
  - in unreferenced / untagged mode on repo A
  - in unreferenced / untagged mode on repo B
