### PR TITLE
Fix delete manifest infinite loop

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -73,7 +73,7 @@ v2Router.delete("/:name+/manifests/:reference", async (req, env: Env) => {
   const tags = await env.REGISTRY.list({
     prefix: `${name}/manifests`,
     limit: isNaN(limitInt) ? 1000 : limitInt,
-    startAfter: last?.toString(),
+    cursor: last?.toString(),
   });
   for (const tag of tags.objects) {
     if (!tag.checksums.sha256) {


### PR DESCRIPTION
When there are many references in the R2 registry, the delete manifest endpoint responds with a 400 request and a cursor.

The `list` call uses `startAfter` which is meant for filenames instead of the `cursor` which makes the `list` call return the same data on each call, despite of what's set in the `last` query parameter.

This leads a caller following the `Link` header without checking whether the URL is the same as before to run into an infinite loop.