### PR TITLE
Add a prefix to the path of multipart uploads

### DIFF
--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -247,7 +247,7 @@ export class R2Registry implements Registry {
       // <path>/<'blobs' | 'manifests'>/<name>
       const parts = object.key.split("/");
       // maybe an upload.
-      if (parts.length === 1) {
+      if (parts.length === 1 || parts[0] === "_uploads") {
         return;
       }
 
@@ -513,7 +513,7 @@ export class R2Registry implements Registry {
     // Generate a unique ID for this upload
     const uuid = crypto.randomUUID();
 
-    const upload = await this.env.REGISTRY.createMultipartUpload("uploads/"+uuid, {
+    const upload = await this.env.REGISTRY.createMultipartUpload("_uploads/"+uuid, {
       customMetadata: { [registryUploadKey]: "true" },
     });
     const state = {
@@ -596,7 +596,7 @@ export class R2Registry implements Registry {
       return { response: new InternalError() };
     }
 
-    const upload = this.env.REGISTRY.resumeMultipartUpload("uploads/"+state.registryUploadId, state.uploadId);
+    const upload = this.env.REGISTRY.resumeMultipartUpload("_uploads/"+state.registryUploadId, state.uploadId);
     const uuid = state.registryUploadId;
     const env = this.env;
 
@@ -819,7 +819,7 @@ export class R2Registry implements Registry {
         sha256: (expectedSha as string).slice(SHA256_PREFIX_LEN),
       });
     } else {
-      const upload_path = "uploads/"+uuid;
+      const upload_path = "_uploads/"+uuid;
       const upload = this.env.REGISTRY.resumeMultipartUpload(upload_path, state.uploadId);
       // TODO: Handle one last buffer here
       await upload.complete(state.parts);
@@ -901,7 +901,7 @@ export class R2Registry implements Registry {
     }
     const state = hashedState.state;
 
-    const upload = this.env.REGISTRY.resumeMultipartUpload("uploads/"+state.registryUploadId, state.uploadId);
+    const upload = this.env.REGISTRY.resumeMultipartUpload("_uploads/"+state.registryUploadId, state.uploadId);
     await upload.abort();
     return true;
   }

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -513,7 +513,7 @@ export class R2Registry implements Registry {
     // Generate a unique ID for this upload
     const uuid = crypto.randomUUID();
 
-    const upload = await this.env.REGISTRY.createMultipartUpload(uuid, {
+    const upload = await this.env.REGISTRY.createMultipartUpload("uploads/"+uuid, {
       customMetadata: { [registryUploadKey]: "true" },
     });
     const state = {
@@ -596,7 +596,7 @@ export class R2Registry implements Registry {
       return { response: new InternalError() };
     }
 
-    const upload = this.env.REGISTRY.resumeMultipartUpload(state.registryUploadId, state.uploadId);
+    const upload = this.env.REGISTRY.resumeMultipartUpload("uploads/"+state.registryUploadId, state.uploadId);
     const uuid = state.registryUploadId;
     const env = this.env;
 
@@ -819,10 +819,11 @@ export class R2Registry implements Registry {
         sha256: (expectedSha as string).slice(SHA256_PREFIX_LEN),
       });
     } else {
-      const upload = this.env.REGISTRY.resumeMultipartUpload(uuid, state.uploadId);
+      const upload_path = "uploads/"+uuid;
+      const upload = this.env.REGISTRY.resumeMultipartUpload(upload_path, state.uploadId);
       // TODO: Handle one last buffer here
       await upload.complete(state.parts);
-      const obj = await this.env.REGISTRY.get(uuid);
+      const obj = await this.env.REGISTRY.get(upload_path);
       if (obj === null) {
         console.error("unreachable, obj is null when we just created upload");
         return {
@@ -853,16 +854,16 @@ export class R2Registry implements Registry {
         }
 
         const [, err] = await wrap(
-          this.env.REGISTRY.put(target, uuid, {
+          this.env.REGISTRY.put(target, upload_path, {
             customMetadata: {
-              [referenceHeader]: uuid,
+              [referenceHeader]: upload_path,
               [digestHeaderInReference]: digest,
             },
           }),
         );
         if (err !== null) {
           console.error("error uploading reference blob", errorString(err));
-          await this.env.REGISTRY.delete(uuid);
+          await this.env.REGISTRY.delete(upload_path);
           return {
             response: new InternalError(),
           };
@@ -872,7 +873,7 @@ export class R2Registry implements Registry {
           sha256: (expectedSha as string).slice(SHA256_PREFIX_LEN),
         });
         const [, err] = await wrap(put);
-        await this.env.REGISTRY.delete(uuid);
+        await this.env.REGISTRY.delete(upload_path);
         if (err !== null) {
           console.error("error uploading blob", errorString(err));
           return {
@@ -900,7 +901,7 @@ export class R2Registry implements Registry {
     }
     const state = hashedState.state;
 
-    const upload = this.env.REGISTRY.resumeMultipartUpload(state.registryUploadId, state.uploadId);
+    const upload = this.env.REGISTRY.resumeMultipartUpload("uploads/"+state.registryUploadId, state.uploadId);
     await upload.abort();
     return true;
   }


### PR DESCRIPTION
Adding a prefix to multipart uploads instead of `/UUID` for better view on R2 dashboard.

Should be merged in https://github.com/cloudflare/serverless-registry/pull/78 before released to master.