### PR TITLE
#107: approve esbuild and workerd dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
   "pnpm": {
     "overrides": {
       "@types/node": "18.15.3"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "workerd"
+    ]
   }
 }


### PR DESCRIPTION
Approve esbuild and workerd to not have to manually approve them each build.

https://github.com/cloudflare/serverless-registry/issues/107