### PR TITLE
fix(r2): return source digest/size for mounted blob HEAD responses

### DIFF
--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -463,10 +463,10 @@ export class R2Registry implements Registry {
       };
     }
 
-    const expectedDigest =
-      tag.startsWith("sha256:") && tag.length > SHA256_PREFIX_LEN ? tag.slice(SHA256_PREFIX_LEN) : null;
+    const expectedDigest = tag.startsWith("sha256:") ? tag : null;
+    const actualDigest = res.checksums.sha256 ? hexToDigest(res.checksums.sha256) : null;
     const symlinkByChecksumMismatch =
-      expectedDigest !== null && res.checksums.sha256 !== null && res.checksums.sha256 !== expectedDigest;
+      expectedDigest !== null && actualDigest !== null && actualDigest !== expectedDigest;
     const symlinkMetadata = res.customMetadata ?? {};
     const symlinkByMetadata = symlinkHeader in symlinkMetadata;
 

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -198,6 +198,8 @@ export async function encodeState(state: State, env: Env): Promise<{ jwt: string
 }
 
 export const symlinkHeader = "X-Serverless-Registry-Symlink";
+export const symlinkDigestHeader = "X-Serverless-Registry-Symlink-Digest";
+export const symlinkSizeHeader = "X-Serverless-Registry-Symlink-Size";
 
 export async function getUploadState(
   name: string,
@@ -650,11 +652,22 @@ export class R2Registry implements Registry {
       // Trying to mount a layer from sourceLayerPath to destinationLayerPath
 
       // Create linked file with custom metadata
+      if (res.checksums.sha256 === null) {
+        return { response: new ServerError("invalid checksum from R2 backend") };
+      }
       const [newFile, error] = await wrap(
         this.env.REGISTRY.put(destinationLayerPath, sourceLayerPath, {
+          // Symlink object content is the source blob path string.
+          // The object checksum must match the symlink payload to satisfy R2.
           sha256: await getSHA256(sourceLayerPath, ""),
           httpMetadata: res.httpMetadata,
-          customMetadata: { [symlinkHeader]: sourceName }, // Storing target repository name in metadata (to easily resolve recursive layer mounting)
+          customMetadata: {
+            // Storing target repository name in metadata (to easily resolve recursive layer mounting)
+            [symlinkHeader]: sourceName,
+            // Store source layer metadata so HEAD can answer without loading symlink body.
+            [symlinkDigestHeader]: digest,
+            [symlinkSizeHeader]: `${res.size}`,
+          },
         }),
       );
       if (error) {
@@ -681,6 +694,63 @@ export class R2Registry implements Registry {
       return {
         exists: false,
       };
+    }
+
+    const expectedDigest =
+      tag.startsWith("sha256:") && tag.length > SHA256_PREFIX_LEN ? tag.slice(SHA256_PREFIX_LEN) : null;
+    const symlinkByChecksumMismatch =
+      expectedDigest !== null && res.checksums.sha256 !== null && res.checksums.sha256 !== expectedDigest;
+    const symlinkMetadata = res.customMetadata ?? {};
+    const symlinkByMetadata = symlinkHeader in symlinkMetadata;
+
+    // Handle R2 symlink layers.
+    // We detect symlinks by:
+    // 1) explicit metadata, or
+    // 2) checksum mismatch between requested digest and R2 object checksum
+    //    (the symlink object checksum is based on symlink payload, not mounted blob bytes).
+    if (symlinkByMetadata || symlinkByChecksumMismatch) {
+      // Fast path for symlinks created by newer versions that include source metadata.
+      const metadataSize = +(symlinkMetadata[symlinkSizeHeader] ?? "");
+      const metadataDigest = symlinkMetadata[symlinkDigestHeader];
+      if (Number.isFinite(metadataSize) && metadataSize >= 0 && metadataDigest) {
+        return {
+          digest: metadataDigest,
+          size: metadataSize,
+          exists: true,
+        };
+      }
+
+      // Backward-compatibility path for old symlinks: resolve link body and query target.
+      const [obj, getErr] = await wrap(this.env.REGISTRY.get(`${name}/blobs/${tag}`));
+      if (getErr) {
+        return wrapError("layerExists", getErr);
+      }
+      if (!obj) {
+        return { exists: false };
+      }
+
+      const layerPath = await obj.text();
+      const [linkName, linkDigest] = layerPath.split("/blobs/");
+      if (!linkName || !linkDigest) {
+        // Backward compatibility: if this does not look like a symlink payload,
+        // fall back to object metadata from HEAD.
+        if (res.checksums.sha256 === null) {
+          return { response: new ServerError("invalid checksum from R2 backend") };
+        }
+
+        return {
+          digest: hexToDigest(res.checksums.sha256!),
+          size: res.size,
+          exists: true,
+        };
+      }
+
+      // Prevent recursive self-reference.
+      if (linkName === name && linkDigest === tag) {
+        return { exists: false };
+      }
+
+      return await this.env.REGISTRY_CLIENT.layerExists(linkName, linkDigest);
     }
 
     return {

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -102,6 +102,8 @@ export async function encodeState(state: State, env: Env): Promise<{ jwt: string
 }
 
 export const symlinkHeader = "X-Serverless-Registry-Symlink";
+export const symlinkDigestHeader = "X-Serverless-Registry-Symlink-Digest";
+export const symlinkSizeHeader = "X-Serverless-Registry-Symlink-Size";
 
 export async function getUploadState(
   name: string,
@@ -417,11 +419,22 @@ export class R2Registry implements Registry {
       // Trying to mount a layer from sourceLayerPath to destinationLayerPath
 
       // Create linked file with custom metadata
+      if (res.checksums.sha256 === null) {
+        return { response: new ServerError("invalid checksum from R2 backend") };
+      }
       const [newFile, error] = await wrap(
         this.env.REGISTRY.put(destinationLayerPath, sourceLayerPath, {
+          // Symlink object content is the source blob path string.
+          // The object checksum must match the symlink payload to satisfy R2.
           sha256: await getSHA256(sourceLayerPath, ""),
           httpMetadata: res.httpMetadata,
-          customMetadata: { [symlinkHeader]: sourceName }, // Storing target repository name in metadata (to easily resolve recursive layer mounting)
+          customMetadata: {
+            // Storing target repository name in metadata (to easily resolve recursive layer mounting)
+            [symlinkHeader]: sourceName,
+            // Store source layer metadata so HEAD can answer without loading symlink body.
+            [symlinkDigestHeader]: digest,
+            [symlinkSizeHeader]: `${res.size}`,
+          },
         }),
       );
       if (error) {
@@ -448,6 +461,63 @@ export class R2Registry implements Registry {
       return {
         exists: false,
       };
+    }
+
+    const expectedDigest =
+      tag.startsWith("sha256:") && tag.length > SHA256_PREFIX_LEN ? tag.slice(SHA256_PREFIX_LEN) : null;
+    const symlinkByChecksumMismatch =
+      expectedDigest !== null && res.checksums.sha256 !== null && res.checksums.sha256 !== expectedDigest;
+    const symlinkMetadata = res.customMetadata ?? {};
+    const symlinkByMetadata = symlinkHeader in symlinkMetadata;
+
+    // Handle R2 symlink layers.
+    // We detect symlinks by:
+    // 1) explicit metadata, or
+    // 2) checksum mismatch between requested digest and R2 object checksum
+    //    (the symlink object checksum is based on symlink payload, not mounted blob bytes).
+    if (symlinkByMetadata || symlinkByChecksumMismatch) {
+      // Fast path for symlinks created by newer versions that include source metadata.
+      const metadataSize = +(symlinkMetadata[symlinkSizeHeader] ?? "");
+      const metadataDigest = symlinkMetadata[symlinkDigestHeader];
+      if (Number.isFinite(metadataSize) && metadataSize >= 0 && metadataDigest) {
+        return {
+          digest: metadataDigest,
+          size: metadataSize,
+          exists: true,
+        };
+      }
+
+      // Backward-compatibility path for old symlinks: resolve link body and query target.
+      const [obj, getErr] = await wrap(this.env.REGISTRY.get(`${name}/blobs/${tag}`));
+      if (getErr) {
+        return wrapError("layerExists", getErr);
+      }
+      if (!obj) {
+        return { exists: false };
+      }
+
+      const layerPath = await obj.text();
+      const [linkName, linkDigest] = layerPath.split("/blobs/");
+      if (!linkName || !linkDigest) {
+        // Backward compatibility: if this does not look like a symlink payload,
+        // fall back to object metadata from HEAD.
+        if (res.checksums.sha256 === null) {
+          return { response: new ServerError("invalid checksum from R2 backend") };
+        }
+
+        return {
+          digest: hexToDigest(res.checksums.sha256!),
+          size: res.size,
+          exists: true,
+        };
+      }
+
+      // Prevent recursive self-reference.
+      if (linkName === name && linkDigest === tag) {
+        return { exists: false };
+      }
+
+      return await this.env.REGISTRY_CLIENT.layerExists(linkName, linkDigest);
     }
 
     return {

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -696,10 +696,10 @@ export class R2Registry implements Registry {
       };
     }
 
-    const expectedDigest =
-      tag.startsWith("sha256:") && tag.length > SHA256_PREFIX_LEN ? tag.slice(SHA256_PREFIX_LEN) : null;
+    const expectedDigest = tag.startsWith("sha256:") ? tag : null;
+    const actualDigest = res.checksums.sha256 ? hexToDigest(res.checksums.sha256) : null;
     const symlinkByChecksumMismatch =
-      expectedDigest !== null && res.checksums.sha256 !== null && res.checksums.sha256 !== expectedDigest;
+      expectedDigest !== null && actualDigest !== null && actualDigest !== expectedDigest;
     const symlinkMetadata = res.customMetadata ?? {};
     const symlinkByMetadata = symlinkHeader in symlinkMetadata;
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -501,9 +501,12 @@ v2Router.put("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
 v2Router.head("/:name+/blobs/:tag", async (req, env: Env) => {
   const { name, tag } = req.params;
 
-  const res = await env.REGISTRY.head(`${name}/blobs/${tag}`);
   let layerExistsResponse: CheckLayerResponse | null = null;
-  if (!res) {
+  const localResponse = await env.REGISTRY_CLIENT.layerExists(name, tag);
+  if ("response" in localResponse) {
+    return localResponse.response;
+  }
+  if (!localResponse.exists) {
     const registryList = registries(env);
     for (const registry of registryList) {
       const client = new RegistryHTTPClient(env, registry);
@@ -521,15 +524,7 @@ v2Router.head("/:name+/blobs/:tag", async (req, env: Env) => {
     if (layerExistsResponse === null || !layerExistsResponse.exists)
       return new Response(JSON.stringify(BlobUnknownError), { status: 404 });
   } else {
-    if (res.checksums.sha256 === null) {
-      throw new ServerError("invalid checksum from R2 backend");
-    }
-
-    layerExistsResponse = {
-      digest: hexToDigest(res.checksums.sha256!),
-      size: res.size,
-      exists: true,
-    };
+    layerExistsResponse = localResponse;
   }
 
   return new Response(null, {

--- a/src/router.ts
+++ b/src/router.ts
@@ -590,9 +590,12 @@ v2Router.put("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
 v2Router.head("/:name+/blobs/:tag", async (req, env: Env) => {
   const { name, tag } = req.params;
 
-  const res = await env.REGISTRY.head(`${name}/blobs/${tag}`);
   let layerExistsResponse: CheckLayerResponse | null = null;
-  if (!res) {
+  const localResponse = await env.REGISTRY_CLIENT.layerExists(name, tag);
+  if ("response" in localResponse) {
+    return localResponse.response;
+  }
+  if (!localResponse.exists) {
     const registryList = registries(env);
     for (const registry of registryList) {
       const client = new RegistryHTTPClient(env, registry);
@@ -610,15 +613,7 @@ v2Router.head("/:name+/blobs/:tag", async (req, env: Env) => {
     if (layerExistsResponse === null || !layerExistsResponse.exists)
       return new Response(JSON.stringify(BlobUnknownError), { status: 404 });
   } else {
-    if (res.checksums.sha256 === null) {
-      throw new ServerError("invalid checksum from R2 backend");
-    }
-
-    layerExistsResponse = {
-      digest: hexToDigest(res.checksums.sha256!),
-      size: res.size,
-      exists: true,
-    };
+    layerExistsResponse = localResponse;
   }
 
   return new Response(null, {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -474,6 +474,17 @@ describe("v2 manifests", () => {
         expect(layerC.ok).toBeTruthy();
         expect(await layerB.bytes()).toEqual(sourceData);
         expect(await layerC.bytes()).toEqual(sourceData);
+
+        // Check layer HEAD returns source metadata for mounted symlinks.
+        const layerHeadB = await fetch(createRequest("HEAD", `/v2/${repoB}/blobs/${layer}`, null));
+        expect(layerHeadB.ok).toBeTruthy();
+        expect(layerHeadB.headers.get("Docker-Content-Digest")).toEqual(layer);
+        expect(+(layerHeadB.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
+
+        const layerHeadC = await fetch(createRequest("HEAD", `/v2/${repoC}/blobs/${layer}`, null));
+        expect(layerHeadC.ok).toBeTruthy();
+        expect(layerHeadC.headers.get("Docker-Content-Digest")).toEqual(layer);
+        expect(+(layerHeadC.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
       }
     }
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -203,6 +203,20 @@ async function createManifest(name: string, schema: ManifestSchema, tag?: string
   return { sha256 };
 }
 
+async function uploadBlob(name: string, data: string): Promise<string> {
+  const digest = await getSHA256(data);
+  const post = await fetch(createRequest("POST", `/v2/${name}/blobs/uploads/`, null, {}));
+  expect(post.ok).toBeTruthy();
+  const patch = await fetch(
+    createRequest("PATCH", post.headers.get("location")!, limit(new Blob([data]).stream(), data.length), {}),
+  );
+  expect(patch.ok).toBeTruthy();
+  const put = await fetch(createRequest("PUT", `${patch.headers.get("location")!}&digest=${digest}`, null, {}));
+  expect(put.ok).toBeTruthy();
+  expect(put.headers.get("docker-content-digest")).toEqual(digest);
+  return digest;
+}
+
 function getLayersFromManifest(schema: ManifestSchema): string[] {
   const layersDigest = [];
   if (schema.schemaVersion === 1) {
@@ -420,6 +434,35 @@ describe("v2 manifests", () => {
         expect(+(layerHeadC.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
       }
     }
+  });
+
+  test("HEAD of a cross-repo mounted blob returns source metadata", async () => {
+    const sourceName = "mountsrc/repo";
+    const destinationName = "mountdst/repo";
+    const data = "cross-repo-mounted-layer-bytes";
+    const digest = await uploadBlob(sourceName, data);
+
+    const mount = await fetch(
+      createRequest("POST", `/v2/${destinationName}/blobs/uploads/?from=${sourceName}&mount=${digest}`, null, {}),
+    );
+    expect(mount.status).toEqual(201);
+    expect(mount.headers.get("docker-content-digest")).toEqual(digest);
+
+    const head = await fetch(createRequest("HEAD", `/v2/${destinationName}/blobs/${digest}`, null));
+    expect(head.status).toEqual(200);
+    expect(head.headers.get("Docker-Content-Digest")).toEqual(digest);
+    expect(head.headers.get("Content-Length")).toEqual(`${data.length}`);
+  });
+
+  test("HEAD of a regular blob with /blobs/ in its body is not resolved as a symlink", async () => {
+    const name = "regular-blob-head";
+    const data = "plain payload before /blobs/ after";
+    const digest = await uploadBlob(name, data);
+
+    const head = await fetch(createRequest("HEAD", `/v2/${name}/blobs/${digest}`, null));
+    expect(head.status).toEqual(200);
+    expect(head.headers.get("Docker-Content-Digest")).toEqual(digest);
+    expect(head.headers.get("Content-Length")).toEqual(`${data.length}`);
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -407,6 +407,17 @@ describe("v2 manifests", () => {
         expect(layerC.ok).toBeTruthy();
         expect(await layerB.bytes()).toEqual(sourceData);
         expect(await layerC.bytes()).toEqual(sourceData);
+
+        // Check layer HEAD returns source metadata for mounted symlinks.
+        const layerHeadB = await fetch(createRequest("HEAD", `/v2/${repoB}/blobs/${layer}`, null));
+        expect(layerHeadB.ok).toBeTruthy();
+        expect(layerHeadB.headers.get("Docker-Content-Digest")).toEqual(layer);
+        expect(+(layerHeadB.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
+
+        const layerHeadC = await fetch(createRequest("HEAD", `/v2/${repoC}/blobs/${layer}`, null));
+        expect(layerHeadC.ok).toBeTruthy();
+        expect(layerHeadC.headers.get("Docker-Content-Digest")).toEqual(layer);
+        expect(+(layerHeadC.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
       }
     }
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -246,6 +246,20 @@ async function createManifest(name: string, schema: ManifestSchema, tag?: string
   return { sha256 };
 }
 
+async function uploadBlob(name: string, data: string): Promise<string> {
+  const digest = await getSHA256(data);
+  const post = await fetch(createRequest("POST", `/v2/${name}/blobs/uploads/`, null, {}));
+  expect(post.ok).toBeTruthy();
+  const patch = await fetch(
+    createRequest("PATCH", post.headers.get("location")!, limit(new Blob([data]).stream(), data.length), {}),
+  );
+  expect(patch.ok).toBeTruthy();
+  const put = await fetch(createRequest("PUT", `${patch.headers.get("location")!}&digest=${digest}`, null, {}));
+  expect(put.ok).toBeTruthy();
+  expect(put.headers.get("docker-content-digest")).toEqual(digest);
+  return digest;
+}
+
 function getLayersFromManifest(schema: ManifestSchema): string[] {
   const layersDigest = [];
   if (schema.schemaVersion === 1) {
@@ -487,6 +501,35 @@ describe("v2 manifests", () => {
         expect(+(layerHeadC.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
       }
     }
+  });
+
+  test("HEAD of a cross-repo mounted blob returns source metadata", async () => {
+    const sourceName = "mountsrc/repo";
+    const destinationName = "mountdst/repo";
+    const data = "cross-repo-mounted-layer-bytes";
+    const digest = await uploadBlob(sourceName, data);
+
+    const mount = await fetch(
+      createRequest("POST", `/v2/${destinationName}/blobs/uploads/?from=${sourceName}&mount=${digest}`, null, {}),
+    );
+    expect(mount.status).toEqual(201);
+    expect(mount.headers.get("docker-content-digest")).toEqual(digest);
+
+    const head = await fetch(createRequest("HEAD", `/v2/${destinationName}/blobs/${digest}`, null));
+    expect(head.status).toEqual(200);
+    expect(head.headers.get("Docker-Content-Digest")).toEqual(digest);
+    expect(head.headers.get("Content-Length")).toEqual(`${data.length}`);
+  });
+
+  test("HEAD of a regular blob with /blobs/ in its body is not resolved as a symlink", async () => {
+    const name = "regular-blob-head";
+    const data = "plain payload before /blobs/ after";
+    const digest = await uploadBlob(name, data);
+
+    const head = await fetch(createRequest("HEAD", `/v2/${name}/blobs/${digest}`, null));
+    expect(head.status).toEqual(200);
+    expect(head.headers.get("Docker-Content-Digest")).toEqual(digest);
+    expect(head.headers.get("Content-Length")).toEqual(`${data.length}`);
   });
 });
 


### PR DESCRIPTION
## Title
fix(r2): return source digest/size for mounted blob HEAD responses

## Summary
Mounted layers in the R2 backend are stored as lightweight "symlink" objects (body like `<repo>/blobs/<digest>`).  
`HEAD /v2/:name/blobs/:digest` could return metadata from that symlink object instead of the mounted source blob.

This caused invalid blob metadata in HEAD responses for mounted layers, including:
- incorrect `Docker-Content-Digest`
- very small `Content-Length` values (commonly around path-string length such as `86`)

Those headers are consumed by OCI clients during push/pull validation and can surface as unauthorized/manifest-corruption style failures in downstream workflows.

## Root Cause
Two pieces combined into the bug:
1. `mountExistingLayer` stores a symlink object whose checksum represents the symlink payload bytes (the path string), not the mounted source blob digest.
2. The blob `HEAD` route read R2 object metadata directly (`env.REGISTRY.head(...)`), bypassing symlink resolution logic.

Result: for mounted blobs, HEAD returned symlink metadata instead of source blob metadata.

## Changes
### 1) Persist source metadata on new symlink objects
File: `src/registry/r2.ts`
- Added custom metadata keys:
  - `X-Serverless-Registry-Symlink-Digest`
  - `X-Serverless-Registry-Symlink-Size`
- When mounting, write these fields from the source layer response.

### 2) Resolve symlinks in `layerExists` (including old symlinks)
File: `src/registry/r2.ts`
- Detect symlink objects by:
  - explicit symlink metadata, or
  - checksum mismatch between requested digest and stored object checksum.
- Fast path (new symlinks): use stored digest/size metadata.
- Backward compatibility (old symlinks): read symlink body, parse `<repo>/blobs/<digest>`, then recursively query `layerExists` on the source target.
- Added safety fallback for malformed payloads and self-reference.

### 3) Route blob HEAD through `layerExists`
File: `src/router.ts`
- Updated `HEAD /v2/:name+/blobs/:tag` to use `env.REGISTRY_CLIENT.layerExists(name, tag)` for local lookups.
- Keeps existing remote-registry fallback behavior when local blob does not exist.

### 4) Add regression assertions
File: `test/index.test.ts`
- Extended recursive layer mounting test to assert mounted blob HEAD returns:
  - `Docker-Content-Digest == layer digest`
  - `Content-Length == source blob byte length`

## Reproduction (before this patch)
1. Push image to `repoA`.
2. Push another image to `repoB` that mounts the same layer from `repoA`.
3. Run `HEAD /v2/repoB/blobs/<mounted-layer-digest>`.
4. Observe mismatch:
   - digest/header can reflect symlink object checksum
   - `Content-Length` can be tiny (e.g. path-length values such as `86`)

## Behavior After Patch
For mounted blobs, `HEAD` now returns source blob metadata (digest + size), including for previously-created symlink objects.

## Compatibility and Risk
- Backward compatible with existing symlink objects already present in R2.
- New symlinks gain metadata for O(1) HEAD resolution.
- Main behavior change is correctness of blob HEAD metadata for mounted layers.

## Test Plan
Executed:
- `npm test -- test/index.test.ts -t "Upload manifests with recursive layer mounting"`
- `npm test -- test/index.test.ts`

Both pass.
