### PR TITLE
Add referrers API support

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,5 +1,30 @@
 import { z } from "zod";
 
+const dockerManifestListContentType = "application/vnd.docker.distribution.manifest.list.v2+json";
+
+const platformSchema = z.object({
+  "architecture": z.string(),
+  "os": z.string(),
+  "os.features": z.array(z.string()).optional(),
+  "os.version": z.string().optional(),
+  "variant": z.string().optional(),
+  "features": z.array(z.string()).optional(),
+});
+
+const descriptorSchema = z.object({
+  mediaType: z.string(),
+  digest: z.string(),
+  size: z.number().int(),
+  annotations: z.record(z.string()).optional(),
+  artifactType: z.string().optional(),
+  urls: z.array(z.string()).optional(),
+  data: z.string().optional(),
+});
+
+const indexDescriptorSchema = descriptorSchema.extend({
+  platform: platformSchema.optional(),
+});
+
 // https://github.com/opencontainers/image-spec/blob/main/manifest.md
 export const manifestSchema = z
   .object({
@@ -7,26 +32,10 @@ export const manifestSchema = z
     artifactType: z.string().optional(),
     // to maintain retrocompatibility of the registry, let's not assume mediaTypes
     mediaType: z.string(),
-    config: z.object({
-      mediaType: z.string(),
-      digest: z.string(),
-      size: z.number().int(),
-    }),
-    layers: z.array(
-      z.object({
-        size: z.number().int(),
-        mediaType: z.string(),
-        digest: z.string(),
-      }),
-    ),
+    config: descriptorSchema,
+    layers: z.array(descriptorSchema),
     annotations: z.record(z.string()).optional(),
-    subject: z
-      .object({
-        mediaType: z.string(),
-        digest: z.string(),
-        size: z.number().int(),
-      })
-      .optional(),
+    subject: descriptorSchema.optional(),
   })
   .or(
     z
@@ -42,24 +51,32 @@ export const manifestSchema = z
       .and(z.record(z.unknown())),
   )
   .or(
-    z.object({
-      schemaVersion: z.literal(2),
-      mediaType: z.string(),
-      manifests: z.array(
-        z.object({
-          mediaType: z.string(),
-          platform: z.object({
-            "architecture": z.string(),
-            "os": z.string(),
-            "os.version": z.string().optional(),
-            "variant": z.string().optional(),
-            "features": z.array(z.string()).optional(),
-          }),
-          digest: z.string(),
-          size: z.number().int(),
-        }),
-      ),
-    }),
+    z
+      .object({
+        schemaVersion: z.literal(2),
+        artifactType: z.string().optional(),
+        mediaType: z.string(),
+        annotations: z.record(z.string()).optional(),
+        subject: descriptorSchema.optional(),
+        manifests: z.array(indexDescriptorSchema),
+      })
+      .superRefine((manifest, ctx) => {
+        if (manifest.mediaType !== dockerManifestListContentType) {
+          return;
+        }
+
+        manifest.manifests.forEach((descriptor, index) => {
+          if (descriptor.platform !== undefined) {
+            return;
+          }
+
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["manifests", index, "platform"],
+            message: "platform is required for docker manifest lists",
+          });
+        });
+      }),
   );
 
 export type ManifestSchema = z.infer<typeof manifestSchema>;

--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -1,10 +1,11 @@
 // We have 2 modes for the garbage collector, unreferenced and untagged.
 // Unreferenced will delete all blobs that are not referenced by any manifest.
-// Untagged will delete all blobs that are not referenced by any manifest and are not tagged.
+// Untagged will delete untagged manifests, any native referrer indexes tied to them, and any blobs
+// that are not referenced by the remaining manifests.
 
 import { ManifestSchema } from "../manifest";
 import { hexToDigest } from "../user";
-import {symlinkHeader} from "./r2";
+import { symlinkHeader } from "./r2";
 
 export type GarbageCollectionMode = "unreferenced" | "untagged";
 export type GCOptions = {
@@ -159,14 +160,14 @@ export class GarbageCollector {
     let cursor = listed.truncated ? listed.cursor : undefined;
 
     while (truncated) {
-      const next = await this.registry.list({ prefix, cursor });
+      const next = await this.registry.list({ prefix, cursor, include: ["customMetadata"] });
       for (const object of next.objects) {
         if ((await callback(object)) === false) {
           return false;
         }
       }
+      cursor = next.truncated ? next.cursor : undefined;
       truncated = next.truncated;
-      cursor = truncated ? cursor : undefined;
     }
     return true;
   }
@@ -199,33 +200,77 @@ export class GarbageCollector {
     // In untagged mode, search for manifest to delete
     if (options.mode === "untagged") {
       const manifestToRemove = new Set<string>();
-      const referencedManifests = new Set<string>();
-      // List tagged manifest to find manifest-list
-      for (const [_, manifests] of Object.entries(manifestList)) {
-        const taggedManifest = [...manifests].filter((item) => !item.split("/").pop()?.startsWith("sha256:"));
-        for (const manifestPath of taggedManifest) {
-          // Tagged manifest some, load manifest content
-          const manifest = await this.registry.get(manifestPath);
-          if (!manifest) {
-            continue;
-          }
+      const liveManifests = new Set<string>();
+      const pendingLiveManifests: string[] = [];
+      const referrerIndexByDigest = new Map<string, string[]>();
+      const referrerIndexBySubject = new Map<string, Array<{ key: string; referrerDigest: string }>>();
+      const referrerDigestsBySubject = new Map<string, Set<string>>();
+      const manifestHasTag = (manifests: Set<string>) => {
+        return [...manifests].some((item) => !item.split("/").pop()?.startsWith("sha256:"));
+      };
+      const markManifestLive = (digest: string) => {
+        if (liveManifests.has(digest)) {
+          return;
+        }
 
-          const manifestData = (await manifest.json()) as ManifestSchema;
-          // Search for manifest list
-          if (manifestData.schemaVersion == 2 && "manifests" in manifestData) {
-            // Extract referenced manifests from manifest list
-            manifestData.manifests.forEach((manifest) => {
-              referencedManifests.add(manifest.digest);
-            });
+        liveManifests.add(digest);
+        pendingLiveManifests.push(digest);
+      };
+      await this.list(`${options.name}/_referrers/`, async (object) => {
+        const parts = object.key.split("/");
+        const subjectDigest = parts[parts.length - 2];
+        const referrerDigest = parts[parts.length - 1];
+        const referrerIndexEntries = referrerIndexByDigest.get(referrerDigest) ?? [];
+        referrerIndexEntries.push(object.key);
+        referrerIndexByDigest.set(referrerDigest, referrerIndexEntries);
+        const subjectIndexEntries = referrerIndexBySubject.get(subjectDigest) ?? [];
+        subjectIndexEntries.push({ key: object.key, referrerDigest });
+        referrerIndexBySubject.set(subjectDigest, subjectIndexEntries);
+        const referrerDigests = referrerDigestsBySubject.get(subjectDigest) ?? new Set<string>();
+        referrerDigests.add(referrerDigest);
+        referrerDigestsBySubject.set(subjectDigest, referrerDigests);
+        return true;
+      });
+
+      // Seed the live set from tagged manifests, then walk manifest indexes and referrer links.
+      for (const [digest, manifests] of Object.entries(manifestList)) {
+        if (manifestHasTag(manifests)) {
+          markManifestLive(digest);
+        }
+      }
+
+      while (pendingLiveManifests.length > 0) {
+        const liveDigest = pendingLiveManifests.pop();
+        if (liveDigest === undefined) {
+          continue;
+        }
+
+        const manifestPath = manifestList[liveDigest]?.values().next().value;
+        if (manifestPath !== undefined) {
+          const manifest = await this.registry.get(manifestPath);
+          if (manifest !== null) {
+            const manifestData = (await manifest.json()) as ManifestSchema;
+            if (manifestData.schemaVersion === 2 && "manifests" in manifestData) {
+              manifestData.manifests.forEach((manifest) => {
+                markManifestLive(manifest.digest);
+              });
+            }
+          }
+        }
+
+        const referrerDigests = referrerDigestsBySubject.get(liveDigest);
+        if (referrerDigests !== undefined) {
+          for (const referrerDigest of referrerDigests) {
+            markManifestLive(referrerDigest);
           }
         }
       }
 
       for (const [key, manifests] of Object.entries(manifestList)) {
-        if (referencedManifests.has(key)) {
+        if (liveManifests.has(key)) {
           continue;
         }
-        if (![...manifests].some((item) => !item.split("/").pop()?.startsWith("sha256:"))) {
+        if (!manifestHasTag(manifests)) {
           // Add untagged manifest that should be removed
           manifests.forEach((manifest) => {
             manifestToRemove.add(manifest);
@@ -235,14 +280,38 @@ export class GarbageCollector {
         }
       }
 
-      // Deleting untagged manifest
+      // Delete untagged manifests and any native referrer index entries tied to them.
       if (manifestToRemove.size > 0) {
         if (!(await this.checkIfGCCanContinue(options.name, mark))) {
           throw new Error("there is a manifest insertion going, the garbage collection shall stop");
         }
 
-        // GC will deleted untagged manifest
-        await this.registry.delete(manifestToRemove.values().toArray());
+        const keysToDelete = new Set<string>(manifestToRemove);
+        const manifestDigestsToRemove = new Set(
+          [...manifestToRemove]
+            .map((manifestPath) => manifestPath.split("/").pop())
+            .filter((manifestDigest): manifestDigest is string => manifestDigest !== undefined),
+        );
+        for (const manifestPath of manifestToRemove) {
+          const manifestDigest = manifestPath.split("/").pop();
+          if (manifestDigest === undefined) {
+            continue;
+          }
+
+          const referrerIndexEntries = referrerIndexByDigest.get(manifestDigest);
+          if (referrerIndexEntries !== undefined) {
+            referrerIndexEntries.forEach((entry) => keysToDelete.add(entry));
+          }
+
+          const subjectIndexEntries = referrerIndexBySubject.get(manifestDigest);
+          if (subjectIndexEntries !== undefined) {
+            subjectIndexEntries
+              .filter((entry) => manifestDigestsToRemove.has(entry.referrerDigest))
+              .forEach((entry) => keysToDelete.add(entry.key));
+          }
+        }
+
+        await this.registry.delete([...keysToDelete]);
       }
     }
 

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -1,5 +1,5 @@
 import { Env } from "../..";
-import { InternalError } from "../errors";
+import { InternalError, ServerError } from "../errors";
 import { errorString } from "../utils";
 import { GarbageCollectionMode } from "./garbage-collector";
 import {
@@ -8,14 +8,17 @@ import {
   FinishedUploadObject,
   GetLayerResponse,
   GetManifestResponse,
+  ListReferrersResponse,
   ListRepositoriesResponse,
   PutManifestResponse,
+  ReferrerDescriptor,
   Registry,
   RegistryConfiguration,
   RegistryError,
   UploadId,
   UploadObject,
 } from "./registry";
+import { ociImageIndexContentType } from "./r2";
 
 type AuthContext = {
   authType: AuthType;
@@ -51,6 +54,92 @@ export const manifestTypes = [
 ] as const;
 
 export type ManifestType = (typeof manifestTypes)[number];
+
+function splitLinkHeaderValues(link: string): string[] {
+  const values: string[] = [];
+  let current = "";
+  let insideAngleBrackets = false;
+  let insideQuotes = false;
+
+  for (const character of link) {
+    if (character === '"' && !insideAngleBrackets) {
+      insideQuotes = !insideQuotes;
+    } else if (character === "<" && !insideQuotes) {
+      insideAngleBrackets = true;
+    } else if (character === ">" && !insideQuotes) {
+      insideAngleBrackets = false;
+    } else if (character === "," && !insideAngleBrackets && !insideQuotes) {
+      values.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += character;
+  }
+
+  if (current.length > 0) {
+    values.push(current.trim());
+  }
+
+  return values;
+}
+
+function parseLinkHeaderURL(link: string, baseURL: string): URL | null {
+  for (const linkValue of splitLinkHeaderValues(link)) {
+    const targetStart = linkValue.indexOf("<");
+    const targetEnd = linkValue.indexOf(">", targetStart + 1);
+    if (targetStart === -1 || targetEnd === -1) {
+      continue;
+    }
+
+    const params = linkValue
+      .slice(targetEnd + 1)
+      .split(";")
+      .map((param) => param.trim())
+      .filter((param) => param.length > 0);
+    const isNext = params.some((param) => {
+      const [name, ...valueParts] = param.split("=");
+      if (name.toLowerCase() !== "rel" || valueParts.length === 0) {
+        return false;
+      }
+
+      const value = valueParts.join("=").trim().replace(/^"|"$/g, "");
+      return value.split(/\s+/).includes("next");
+    });
+    if (!isNext) {
+      continue;
+    }
+
+    const href = linkValue.slice(targetStart + 1, targetEnd).trim();
+    try {
+      return new URL(href);
+    } catch {
+      if (baseURL.length === 0) {
+        return null;
+      }
+
+      try {
+        return new URL(href, baseURL);
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  return null;
+}
+
+function isOpaqueReferrersCursor(cursor: string): boolean {
+  return cursor.startsWith("/v2/");
+}
+
+function normalizeReferrersCursor(nextURL: URL, requestURL: URL): string | undefined {
+  if (nextURL.origin !== requestURL.origin || nextURL.pathname !== requestURL.pathname) {
+    return undefined;
+  }
+
+  return `${nextURL.pathname}${nextURL.search}`;
+}
 
 function ctxIntoHeaders(ctx: HTTPContext): Headers {
   const headers = new Headers();
@@ -225,7 +314,7 @@ export class RegistryHTTPClient implements Registry {
     return false;
   }
 
-  async authenticateBearerSimple(ctx: AuthContext, params: URLSearchParams): Promise<Response> {
+  async authenticateBearerSimple(ctx: AuthContext, params: URLSearchParams) {
     params.delete("password");
     console.log("sending authentication parameters:", ctx.realm + "?" + params.toString());
 
@@ -467,6 +556,100 @@ export class RegistryHTTPClient implements Registry {
       };
     } catch (err) {
       console.error(`Error doing get layer with ${namespace} and ${digest}: ` + errorString(err));
+      return {
+        response: new InternalError(),
+      };
+    }
+  }
+
+  async listReferrers(
+    name: string,
+    digest: string,
+    options?: {
+      artifactType?: string;
+      limit?: number;
+      last?: string;
+    },
+  ): Promise<ListReferrersResponse | RegistryError> {
+    const namespace = name.includes("/") || !isDockerDotIO(this.url) ? name : `library/${name}`;
+    try {
+      const ctx = await this.authenticate(namespace);
+      const baseRequest = ctxIntoRequest(ctx, this.url, "GET", `${namespace}/referrers/${digest}`);
+      const baseURL = new URL(baseRequest.url);
+      let req: Request;
+      const usesOpaqueCursor = options?.last !== undefined && isOpaqueReferrersCursor(options.last);
+      if (usesOpaqueCursor) {
+        const nextCursor = options!.last!;
+        const nextURL = nextCursor.startsWith("/")
+          ? new URL(nextCursor, `${this.url.protocol}//${this.url.host}`)
+          : new URL(nextCursor);
+        if (nextURL.origin !== baseURL.origin || nextURL.pathname !== baseURL.pathname) {
+          return {
+            response: new ServerError("invalid referrers cursor", 400),
+          };
+        }
+        req = new Request(nextURL, {
+          method: "GET",
+          headers: ctxIntoHeaders(ctx),
+        });
+      } else {
+        const params = new URLSearchParams();
+        if (options?.artifactType !== undefined) {
+          params.set("artifactType", options.artifactType);
+        }
+        if (options?.limit !== undefined) {
+          params.set("n", `${options.limit}`);
+        }
+        if (options?.last !== undefined) {
+          params.set("last", options.last);
+        }
+
+        req = ctxIntoRequest(
+          ctx,
+          this.url,
+          "GET",
+          `${namespace}/referrers/${digest}${params.size > 0 ? `?${params.toString()}` : ""}`,
+        );
+      }
+
+      const res = await fetch(req);
+      console.log(req.method, res.status, res.url);
+      if (!res.ok) {
+        return {
+          response: res,
+        };
+      }
+
+      const body = (await res.json()) as {
+        manifests?: ReferrerDescriptor[];
+        mediaType?: string;
+        schemaVersion?: number;
+      };
+      const contentType = res.headers.get("Content-Type")?.split(";")[0].trim();
+      if (
+        contentType !== ociImageIndexContentType ||
+        body.schemaVersion !== 2 ||
+        body.mediaType !== ociImageIndexContentType ||
+        !Array.isArray(body.manifests)
+      ) {
+        return {
+          response: new InternalError(),
+        };
+      }
+
+      const next = res.headers.get("Link");
+      let cursor: string | undefined;
+      if (next !== null) {
+        const nextURL = parseLinkHeaderURL(next, res.url);
+        cursor = nextURL !== null ? normalizeReferrersCursor(nextURL, new URL(req.url)) : undefined;
+      }
+
+      return {
+        manifests: body.manifests,
+        cursor,
+      };
+    } catch (err) {
+      console.error(`Error doing list referrers with ${namespace} and ${digest}: ` + errorString(err));
       return {
         response: new InternalError(),
       };

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -10,7 +10,7 @@ import {
   split,
 } from "../chunk";
 import { InternalError, ManifestError, RangeError, ServerError } from "../errors";
-import { SHA256_PREFIX_LEN, getSHA256, hexToDigest } from "../user";
+import { SHA256_PREFIX_LEN, getSHA256, hexToDigest, isValidDigest } from "../user";
 import { readableToBlob, readerToBlob, wrap } from "../utils";
 import { BlobUnknownError, ManifestUnknownError } from "../v2-errors";
 import {
@@ -19,8 +19,10 @@ import {
   FinishedUploadObject,
   GetLayerResponse,
   GetManifestResponse,
+  ListReferrersResponse,
   ListRepositoriesResponse,
   PutManifestResponse,
+  ReferrerDescriptor,
   Registry,
   RegistryError,
   UploadId,
@@ -29,6 +31,100 @@ import {
 } from "./registry";
 import { GarbageCollectionMode, GarbageCollector } from "./garbage-collector";
 import { ManifestSchema, manifestSchema } from "../manifest";
+
+export const ociImageIndexContentType = "application/vnd.oci.image.index.v1+json";
+
+function referrersPrefix(name: string, digest: string): string {
+  return `${name}/_referrers/${digest}/`;
+}
+
+function referrersPath(name: string, subjectDigest: string, digest: string): string {
+  return `${referrersPrefix(name, subjectDigest)}${digest}`;
+}
+
+function artifactTypeFromManifest(manifest: ManifestSchema): string | undefined {
+  if (manifest.schemaVersion !== 2) {
+    return undefined;
+  }
+
+  if (manifest.artifactType && manifest.artifactType.length > 0) {
+    return manifest.artifactType;
+  }
+
+  if ("manifests" in manifest) {
+    return undefined;
+  }
+
+  return manifest.config.mediaType.length > 0 ? manifest.config.mediaType : undefined;
+}
+
+function descriptorFromManifest(manifest: ManifestSchema, digest: string, size: number): ReferrerDescriptor | null {
+  if (manifest.schemaVersion !== 2 || manifest.subject === undefined) {
+    return null;
+  }
+
+  const descriptor: ReferrerDescriptor = {
+    mediaType: manifest.mediaType,
+    digest,
+    size,
+  };
+
+  const artifactType = artifactTypeFromManifest(manifest);
+  if (artifactType !== undefined) {
+    descriptor.artifactType = artifactType;
+  }
+
+  if (manifest.annotations !== undefined) {
+    descriptor.annotations = manifest.annotations;
+  }
+
+  return descriptor;
+}
+
+function parseStoredReferrerDescriptor(descriptor: unknown, expectedDigest: string): ReferrerDescriptor | null {
+  if (typeof descriptor !== "object" || descriptor === null) {
+    return null;
+  }
+
+  const candidate = descriptor as Record<string, unknown>;
+  if (
+    typeof candidate.mediaType !== "string" ||
+    typeof candidate.digest !== "string" ||
+    candidate.digest !== expectedDigest ||
+    typeof candidate.size !== "number" ||
+    !Number.isInteger(candidate.size) ||
+    candidate.size < 0
+  ) {
+    return null;
+  }
+
+  const parsedDescriptor: ReferrerDescriptor = {
+    mediaType: candidate.mediaType,
+    digest: candidate.digest,
+    size: candidate.size,
+  };
+
+  if (candidate.artifactType !== undefined) {
+    if (typeof candidate.artifactType !== "string") {
+      return null;
+    }
+    parsedDescriptor.artifactType = candidate.artifactType;
+  }
+
+  if (candidate.annotations !== undefined) {
+    if (typeof candidate.annotations !== "object" || candidate.annotations === null) {
+      return null;
+    }
+
+    const annotations = Object.entries(candidate.annotations);
+    if (!annotations.every((entry): entry is [string, string] => typeof entry[1] === "string")) {
+      return null;
+    }
+    parsedDescriptor.annotations = Object.fromEntries(annotations);
+  }
+
+  return parsedDescriptor;
+}
 
 export type Chunk =
   | {
@@ -162,9 +258,9 @@ export class R2Registry implements Registry {
 
   async listRepositories(limit?: number, last?: string): Promise<RegistryError | ListRepositoriesResponse> {
     // The idea in listRepositories is list all entries in the R2 bucket and map them to repositories.
-    // We do this by taking advantage of the name format in the R2 bucket:
-    // name format is:
-    //   <path>/<'blobs' | 'manifests'>/<name>
+    // The bucket also contains internal keys like _referrers/, but repository discovery only derives
+    // repositories from manifest paths with the following shape:
+    //   <path>/manifests/<name>
     // This means we slice the last two items in the key and add them to our hash map.
     // At the end, we start skipping entries until we find another unique key, then we return that entry as startAfter.
 
@@ -196,8 +292,10 @@ export class R2Registry implements Registry {
       // name format is:
       // <path>/<'blobs' | 'manifests'>/<name>
       const parts = object.key.split("/");
+      if (parts[parts.length - 2] !== "manifests") {
+        return;
+      }
       const repository = parts.slice(0, parts.length - 2).join("/");
-      if (parts[parts.length - 2] === "blobs") return;
 
       if (repository in repositories) return;
       totalRecords++;
@@ -288,6 +386,85 @@ export class R2Registry implements Registry {
     return null;
   }
 
+  async listReferrers(
+    name: string,
+    digest: string,
+    options?: {
+      artifactType?: string;
+      limit?: number;
+      last?: string;
+    },
+  ): Promise<ListReferrersResponse | RegistryError> {
+    if (options?.last !== undefined && !isValidDigest(options.last)) {
+      return {
+        response: new ServerError("invalid referrers cursor", 400),
+      };
+    }
+
+    const limit = Math.min(Math.max(Math.trunc(options?.limit ?? 100), 1), 1000);
+    const prefix = referrersPrefix(name, digest);
+    const manifests: ReferrerDescriptor[] = [];
+    const pageSize = Math.min(Math.max(limit + 1, 100), 1000);
+
+    let objects = await this.env.REGISTRY.list({
+      prefix,
+      limit: pageSize,
+      startAfter: options?.last ? referrersPath(name, digest, options.last) : undefined,
+    });
+
+    while (true) {
+      for (const object of objects.objects) {
+        const descriptorObject = await this.env.REGISTRY.get(object.key);
+        if (descriptorObject === null) {
+          continue;
+        }
+
+        const expectedDigest = object.key.split("/").pop();
+        if (expectedDigest === undefined) {
+          continue;
+        }
+
+        let descriptorJSON: unknown;
+        try {
+          descriptorJSON = await descriptorObject.json();
+        } catch {
+          continue;
+        }
+
+        const descriptor = parseStoredReferrerDescriptor(descriptorJSON, expectedDigest);
+        if (descriptor === null) {
+          continue;
+        }
+
+        if (options?.artifactType !== undefined && descriptor.artifactType !== options.artifactType) {
+          continue;
+        }
+
+        manifests.push(descriptor);
+        if (manifests.length > limit) {
+          return {
+            manifests: manifests.slice(0, limit),
+            cursor: manifests[limit - 1].digest,
+          };
+        }
+      }
+
+      if (!objects.truncated) {
+        break;
+      }
+
+      objects = await this.env.REGISTRY.list({
+        prefix,
+        limit: pageSize,
+        cursor: objects.cursor,
+      });
+    }
+
+    return {
+      manifests,
+    };
+  }
+
   async putManifest(
     namespace: string,
     reference: string,
@@ -333,8 +510,44 @@ export class R2Registry implements Registry {
     const digest = await sha256.digest;
     const digestStr = hexToDigest(digest);
     const text = await blob.text();
-    const manifestJSON = JSON.parse(text);
-    const manifest = manifestSchema.parse(manifestJSON);
+    let manifestJSON: unknown;
+    try {
+      manifestJSON = JSON.parse(text);
+    } catch {
+      return {
+        response: new ManifestError("MANIFEST_INVALID", "invalid manifest JSON"),
+      };
+    }
+
+    const manifestResult = manifestSchema.safeParse(manifestJSON);
+    if (!manifestResult.success) {
+      const firstIssue = manifestResult.error.issues[0];
+      const path = firstIssue?.path.length ? `${firstIssue.path.join(".")}: ` : "";
+      return {
+        response: new ManifestError("MANIFEST_INVALID", `${path}${firstIssue?.message ?? "invalid manifest"}`),
+      };
+    }
+
+    const manifest = manifestResult.data;
+    const subjectDigest = manifest.schemaVersion === 2 ? manifest.subject?.digest : undefined;
+    if (subjectDigest !== undefined && !isValidDigest(subjectDigest)) {
+      return {
+        response: new ManifestError("MANIFEST_INVALID", `invalid subject digest ${subjectDigest}`),
+      };
+    }
+    if (subjectDigest !== undefined) {
+      const [subjectManifest, subjectManifestErr] = await wrap(env.REGISTRY.head(`${name}/manifests/${subjectDigest}`));
+      if (subjectManifestErr) {
+        return wrapError("putManifestInner", subjectManifestErr);
+      }
+      if (subjectManifest === null) {
+        return {
+          response: new ManifestError("BLOB_UNKNOWN", `unknown subject ${subjectDigest}`),
+        };
+      }
+    }
+
+    const referrerDescriptor = descriptorFromManifest(manifest, digestStr, blob.size);
     if (checkLayers) {
       const verifyManifestErr = await this.verifyManifest(name, manifest);
       if (verifyManifestErr !== null) return { response: verifyManifestErr };
@@ -345,6 +558,11 @@ export class R2Registry implements Registry {
       return { response: new ServerError("garbage collection is on-going... check with registry administrator", 500) };
     }
 
+    const customMetadata = {
+      hasSubject: subjectDigest !== undefined ? "true" : "false",
+      ...(subjectDigest !== undefined ? { subjectDigest } : {}),
+    };
+
     const putReference = async () => {
       // if the reference is the same as a digest, it's not necessary to insert
       if (reference === digestStr) return;
@@ -353,10 +571,11 @@ export class R2Registry implements Registry {
         httpMetadata: {
           contentType,
         },
+        customMetadata,
       });
     };
 
-    await Promise.all([
+    const putTasks: Promise<unknown>[] = [
       putReference(),
       // this is the "main" manifest
       env.REGISTRY.put(`${name}/manifests/${digestStr}`, text, {
@@ -364,11 +583,25 @@ export class R2Registry implements Registry {
         httpMetadata: {
           contentType,
         },
+        customMetadata,
       }),
-    ]);
+    ];
+
+    if (referrerDescriptor !== null && subjectDigest !== undefined) {
+      putTasks.push(
+        env.REGISTRY.put(referrersPath(name, subjectDigest, digestStr), JSON.stringify(referrerDescriptor), {
+          httpMetadata: {
+            contentType: "application/json",
+          },
+        }),
+      );
+    }
+
+    await Promise.all(putTasks);
     return {
       digest: hexToDigest(digest),
       location: `/v2/${name}/manifests/${reference}`,
+      subject: subjectDigest,
     };
   }
 

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -106,10 +106,24 @@ export type GetLayerResponse = {
   size: number;
 };
 
+export type ReferrerDescriptor = {
+  mediaType: string;
+  digest: string;
+  size: number;
+  artifactType?: string;
+  annotations?: Record<string, string>;
+};
+
+export type ListReferrersResponse = {
+  manifests: ReferrerDescriptor[];
+  cursor?: string;
+};
+
 // returned by putManifest when it successfully uploads a manifest
 export type PutManifestResponse = {
   digest: string;
   location: string;
+  subject?: string;
 };
 
 // Registry interface to an implementation
@@ -137,6 +151,17 @@ export interface Registry {
 
   // get a layer stream from the registry
   getLayer(namespace: string, digest: string): Promise<GetLayerResponse | RegistryError>;
+
+  // list referrers for a subject digest
+  listReferrers(
+    namespace: string,
+    digest: string,
+    options?: {
+      artifactType?: string;
+      limit?: number;
+      last?: string;
+    },
+  ): Promise<ListReferrersResponse | RegistryError>;
 
   // put manifest uploads a manifest into the registry
   putManifest(

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,7 +2,7 @@ import { Router } from "itty-router";
 import { BlobUnknownError, ManifestUnknownError } from "./v2-errors";
 import { InternalError, ServerError } from "./errors";
 import { errorString, jsonHeaders, wrap } from "./utils";
-import { hexToDigest } from "./user";
+import { hexToDigest, isValidDigest } from "./user";
 import { ManifestTagsListTooBigError } from "./v2-responses";
 import { Env } from "..";
 import { MINIMUM_CHUNK, MAXIMUM_CHUNK, MAXIMUM_CHUNK_UPLOAD_SIZE } from "./chunk";
@@ -18,6 +18,14 @@ import {
   registries,
 } from "./registry/registry";
 import { RegistryHTTPClient } from "./registry/http";
+import { ociImageIndexContentType } from "./registry/r2";
+
+const maxReferrersListLimit = 1000;
+const isOpaqueReferrersCursor = (cursor: string) => cursor.startsWith("/v2/");
+
+function formatNextLink(url: URL): string {
+  return `<${url.toString()}>; rel="next"`;
+}
 
 const v2Router = Router({ base: "/v2/" });
 
@@ -50,29 +58,47 @@ v2Router.get("/_catalog", async (req, env: Env) => {
 });
 
 v2Router.delete("/:name+/manifests/:reference", async (req, env: Env) => {
-  // deleting a manifest works by retrieving the """main""" manifest that its key is a sha,
-  // and then going through every tag and removing it
+  // Deleting by digest removes every tag alias that points at that digest before removing
+  // the digest manifest itself. Deleting by tag only removes that tag entry.
   //
-  // after removing every tag, it's safe to remove the main manifest.
+  // If the deleted manifest is itself a referrer, remove its native subject-linked index entry.
+  // Subject-side referrer cleanup can be deferred until GC prunes those manifests.
   //
-  // if the transaction ends in an inconsistent state, the client can call this endpoint again
-  // and we would try to delete everything again
+  // If the transaction ends in an inconsistent state, the client can call this endpoint again
+  // and we will retry the cleanup.
   //
-  // we limit 1k tag deletions per request. If more we will return an error so client retries.
+  // We scan up to the requested number of manifest entries (default 1k) while looking for matching
+  // tag aliases. If more entries remain, return an error so the client can continue with the
+  // provided cursor.
   //
-  // If somehow we need to remove by paginating, we accept a last query param
+  // If somehow we need to remove by paginating, we accept a last query param.
 
   const { last, limit } = req.query;
   const { name, reference } = req.params;
-  // Reference is ALWAYS a sha256
   const manifest = await env.REGISTRY.head(`${name}/manifests/${reference}`);
   if (manifest === null) {
     return new Response(JSON.stringify(ManifestUnknownError(reference)), { status: 404, headers: jsonHeaders() });
   }
+  const manifestDigest = hexToDigest(manifest.checksums.sha256!);
+  let subjectDigest = manifest.customMetadata?.subjectDigest;
+  if (subjectDigest === undefined && manifest.customMetadata?.hasSubject !== "false") {
+    const manifestBody = await env.REGISTRY.get(`${name}/manifests/${reference}`);
+    if (manifestBody !== null) {
+      try {
+        const manifestJSON = (await manifestBody.json()) as { subject?: { digest: string } };
+        subjectDigest = manifestJSON.subject?.digest;
+      } catch {
+        subjectDigest = undefined;
+      }
+    }
+  }
   const limitInt = parseInt(limit?.toString() ?? "1000", 10);
+  if (!Number.isInteger(limitInt) || limitInt <= 0 || limitInt > 1000) {
+    throw new ServerError("invalid 'limit' parameter", 400);
+  }
   const tags = await env.REGISTRY.list({
     prefix: `${name}/manifests`,
-    limit: isNaN(limitInt) ? 1000 : limitInt,
+    limit: limitInt,
     cursor: last?.toString(),
   });
   for (const tag of tags.objects) {
@@ -80,7 +106,7 @@ v2Router.delete("/:name+/manifests/:reference", async (req, env: Env) => {
       continue;
     }
 
-    if (hexToDigest(tag.checksums.sha256) === reference) {
+    if (hexToDigest(tag.checksums.sha256) === reference && tag.key !== `${name}/manifests/${reference}`) {
       await env.REGISTRY.delete(tag.key);
     }
   }
@@ -91,14 +117,20 @@ v2Router.delete("/:name+/manifests/:reference", async (req, env: Env) => {
     return new Response(JSON.stringify(ManifestTagsListTooBigError), {
       status: 400,
       headers: {
-        "Link": `${url.toString()}; rel=next`,
+        "Link": formatNextLink(url),
         "Content-Type": "application/json",
       },
     });
   }
 
-  // Last but not least, delete the digest manifest
+  // Last but not least, delete the manifest entry and remove the deleted manifest's own referrer
+  // index entry if it points at another subject.
   await env.REGISTRY.delete(`${name}/manifests/${reference}`);
+  if (reference === manifestDigest) {
+    if (subjectDigest !== undefined && isValidDigest(subjectDigest)) {
+      await env.REGISTRY.delete(`${name}/_referrers/${subjectDigest}/${manifestDigest}`);
+    }
+  }
   return new Response("", {
     status: 202,
     headers: {
@@ -265,8 +297,65 @@ v2Router.put("/:name+/manifests/:reference", async (req, env: Env) => {
     headers: {
       "Location": res.location,
       "Docker-Content-Digest": res.digest,
+      ...(res.subject ? { "OCI-Subject": res.subject } : {}),
     },
   });
+});
+
+v2Router.get("/:name+/referrers/:digest", async (req, env: Env) => {
+  const { name, digest } = req.params;
+  if (!isValidDigest(digest)) {
+    throw new ServerError("invalid digest", 400);
+  }
+
+  const { artifactType, last, n: nStr = 100 } = req.query;
+  const n = Number(nStr);
+  if (!Number.isInteger(n) || n <= 0 || n > maxReferrersListLimit) {
+    throw new ServerError("invalid 'n' parameter", 400);
+  }
+  if (last !== undefined && !isValidDigest(last.toString()) && !isOpaqueReferrersCursor(last.toString())) {
+    throw new ServerError("invalid 'last' parameter", 400);
+  }
+
+  const response = await env.REGISTRY_CLIENT.listReferrers(name, digest, {
+    artifactType: artifactType?.toString(),
+    last: last?.toString(),
+    limit: n,
+  });
+  if ("response" in response) {
+    return response.response;
+  }
+
+  const url = new URL(req.url);
+  url.searchParams.set("n", `${n}`);
+  if (artifactType !== undefined) {
+    url.searchParams.set("artifactType", artifactType.toString());
+  }
+  if (response.cursor !== undefined) {
+    url.searchParams.set("last", response.cursor);
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": ociImageIndexContentType,
+  };
+  if (artifactType !== undefined) {
+    headers["OCI-Filters-Applied"] = "artifactType";
+  }
+  if (response.cursor !== undefined) {
+    headers.Link = formatNextLink(url);
+  }
+
+  return new Response(
+    JSON.stringify({
+      schemaVersion: 2,
+      mediaType: ociImageIndexContentType,
+      manifests: response.manifests,
+    }),
+    {
+      status: 200,
+      headers,
+    },
+  );
 });
 
 v2Router.get("/:name+/blobs/:digest", async (req, env: Env, context: ExecutionContext) => {

--- a/src/user.ts
+++ b/src/user.ts
@@ -6,10 +6,36 @@ import type { RegistryTokenCapability } from "./auth";
 export const SHA256_PREFIX = "sha256";
 export const SHA256_PREFIX_LEN = SHA256_PREFIX.length + 1; // add ":"
 
+const digestPattern = /^([a-z0-9]+(?:[+._-][a-z0-9]+)*):([A-Za-z0-9=_-]+)$/;
+const algorithmSpecificDigestPatterns: Record<string, RegExp> = {
+  blake3: /^[a-f0-9]{64}$/,
+  sha256: /^[a-f0-9]{64}$/,
+  sha512: /^[a-f0-9]{128}$/,
+};
+
 export function hexToDigest(sha256: ArrayBuffer, prefix: string = SHA256_PREFIX + ":") {
   const digest = [...new Uint8Array(sha256)].map((b) => b.toString(16).padStart(2, "0")).join("");
 
   return `${prefix}${digest}`;
+}
+
+export function isValidDigest(digest: string): boolean {
+  if (digest.length === 0) {
+    return false;
+  }
+
+  const match = digestPattern.exec(digest);
+  if (match === null) {
+    return false;
+  }
+
+  const [, algorithm, encoded] = match;
+  const algorithmSpecificPattern = algorithmSpecificDigestPatterns[algorithm];
+  if (algorithmSpecificPattern !== undefined) {
+    return algorithmSpecificPattern.test(encoded);
+  }
+
+  return true;
 }
 
 function stringToArrayBuffer(s: string): ArrayBuffer {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,12 +5,19 @@ import { Env } from "..";
 import { RegistryTokens } from "../src/token";
 import { RegistryAuthProtocolTokenPayload } from "../src/auth";
 import { registries } from "../src/registry/registry";
+import type { ReferrerDescriptor } from "../src/registry/registry";
 import { isDockerDotIO, RegistryHTTPClient } from "../src/registry/http";
 import { encode } from "@cfworker/base64url";
 import { ManifestSchema } from "../src/manifest";
 import { limit } from "../src/chunk";
 import worker from "../index";
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+
+type ReferrersIndex = {
+  schemaVersion: 2;
+  mediaType: string;
+  manifests: ReferrerDescriptor[];
+};
 
 async function generateManifest(name: string, schemaVersion: 1 | 2 = 2): Promise<ManifestSchema> {
   // Layer data
@@ -100,6 +107,16 @@ function shuffleArray<T>(array: T[]) {
   return array;
 }
 
+function parseLinkHeaderURL(link: string): URL {
+  const rawURL = link.split(";")[0].trim();
+  const href = rawURL.startsWith("<") && rawURL.endsWith(">") ? rawURL.slice(1, -1) : rawURL;
+  return new URL(href);
+}
+
+function numberedDigest(index: number): string {
+  return `sha256:${index.toString(16).padStart(64, "0")}`;
+}
+
 function usernamePasswordToAuth(username: string, password: string): string {
   return `Basic ${btoa(`${username}:${password}`)}`;
 }
@@ -183,23 +200,44 @@ describe("v2", () => {
   });
 });
 
-async function createManifest(name: string, schema: ManifestSchema, tag?: string): Promise<{ sha256: string }> {
+function getImageManifestV2(schema: ManifestSchema) {
+  if (schema.schemaVersion !== 2 || "manifests" in schema) {
+    throw new Error("expected OCI image manifest");
+  }
+
+  return schema;
+}
+
+function manifestSize(schema: ManifestSchema): number {
+  return new Blob([JSON.stringify(schema)]).size;
+}
+
+async function uploadManifest(
+  name: string,
+  schema: ManifestSchema,
+  tag?: string,
+): Promise<{ sha256: string; response: Response }> {
   const data = JSON.stringify(schema);
   const sha256 = await getSHA256(data);
   if (!tag) {
     tag = sha256;
   }
 
-  const res = await fetch(
+  const response = await fetch(
     createRequest("PUT", `/v2/${name}/manifests/${tag}`, new Blob([data]).stream(), {
       "Content-Type": "application/gzip",
     }),
   );
-  if (!res.ok) {
-    throw new Error(await res.text());
+  if (!response.ok) {
+    throw new Error(await response.text());
   }
-  expect(res.ok).toBeTruthy();
-  expect(res.headers.get("docker-content-digest")).toEqual(sha256);
+  expect(response.ok).toBeTruthy();
+  expect(response.headers.get("docker-content-digest")).toEqual(sha256);
+  return { sha256, response };
+}
+
+async function createManifest(name: string, schema: ManifestSchema, tag?: string): Promise<{ sha256: string }> {
+  const { sha256 } = await uploadManifest(name, schema, tag);
   return { sha256 };
 }
 
@@ -234,6 +272,37 @@ async function mountLayersFromManifest(from: string, schema: ManifestSchema, nam
   }
 
   return layersDigest.length;
+}
+
+async function getReferrersIndex(name: string, digest: string, params?: URLSearchParams) {
+  const query = params?.toString();
+  const response = await fetch(
+    createRequest("GET", `/v2/${name}/referrers/${digest}${query ? `?${query}` : ""}`, null),
+  );
+  expect(response.ok).toBeTruthy();
+  return {
+    response,
+    body: (await response.json()) as ReferrersIndex,
+  };
+}
+
+async function seedReferrerIndex(name: string, subjectDigest: string, descriptors: ReferrerDescriptor[]) {
+  const bindings = env as Env;
+  for (let start = 0; start < descriptors.length; start += 100) {
+    await Promise.all(
+      descriptors.slice(start, start + 100).map((descriptor) => {
+        return bindings.REGISTRY.put(
+          `${name}/_referrers/${subjectDigest}/${descriptor.digest}`,
+          JSON.stringify(descriptor),
+          {
+            httpMetadata: {
+              contentType: "application/json",
+            },
+          },
+        );
+      }),
+    );
+  }
 }
 
 describe("v2 manifests", () => {
@@ -323,19 +392,16 @@ describe("v2 manifests", () => {
   });
 
   test("PUT then list tags with GET /v2/:name/tags/list", async () => {
-    const manifestList = new Set<string>();
-    const { sha256 } = await createManifest("hello-world-list", await generateManifest("hello-world-list"), `hello`);
-    manifestList.add(sha256);
+    await createManifest("hello-world-list", await generateManifest("hello-world-list"), `hello`);
     const expectedRes = ["hello"];
-    for (let i = 0; i < 40; i++) {
+    for (let i = 0; i < 10; i++) {
       expectedRes.push(`hello-${i}`);
     }
 
     expectedRes.sort();
     const shuffledRes = shuffleArray([...expectedRes]);
     for (const tag of shuffledRes) {
-      const { sha256 } = await createManifest("hello-world-list", await generateManifest("hello-world-list"), tag);
-      manifestList.add(sha256);
+      await createManifest("hello-world-list", await generateManifest("hello-world-list"), tag);
     }
 
     const tagsRes = await fetch(createRequest("GET", `/v2/hello-world-list/tags/list?n=1000`, null));
@@ -343,11 +409,7 @@ describe("v2 manifests", () => {
     expect(tags.name).toEqual("hello-world-list");
     expect(tags.tags).toEqual(expectedRes);
 
-    for (const manifestSha256 of manifestList) {
-      const res = await fetch(createRequest("DELETE", `/v2/hello-world-list/manifests/${manifestSha256}`, null));
-      expect(res.ok).toBeTruthy();
-    }
-    const tagsResEmpty = await fetch(createRequest("GET", `/v2/hello-world-list/tags/list`, null));
+    const tagsResEmpty = await fetch(createRequest("GET", `/v2/hello-world-list-empty/tags/list`, null));
     const tagsEmpty = (await tagsResEmpty.json()) as TagsList;
     expect(tagsEmpty.tags).toHaveLength(0);
   });
@@ -409,6 +471,745 @@ describe("v2 manifests", () => {
         expect(await layerC.bytes()).toEqual(sourceData);
       }
     }
+  });
+});
+
+describe("v2 referrers", () => {
+  test("PUT with subject indexes referrers and paginates results", async () => {
+    const name = "referrers-index";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+
+    const subjectDescriptor = {
+      mediaType: subjectManifest.mediaType,
+      digest: subjectDigest,
+      size: manifestSize(subjectManifest),
+    };
+    const artifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const artifactManifestOne = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType,
+      annotations: {
+        "org.opencontainers.image.title": "chain-one",
+      },
+      subject: subjectDescriptor,
+    } satisfies ManifestSchema;
+    const artifactManifestTwo = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType,
+      annotations: {
+        "org.opencontainers.image.title": "chain-two",
+      },
+      subject: subjectDescriptor,
+    } satisfies ManifestSchema;
+
+    const { sha256: firstArtifactDigest, response: firstArtifactResponse } = await uploadManifest(
+      name,
+      artifactManifestOne,
+    );
+    const { sha256: secondArtifactDigest } = await createManifest(name, artifactManifestTwo);
+
+    expect(firstArtifactResponse.headers.get("oci-subject")).toEqual(subjectDigest);
+
+    const descriptorObject = await bindings.REGISTRY.get(`${name}/_referrers/${subjectDigest}/${firstArtifactDigest}`);
+    expect(descriptorObject).not.toBeNull();
+    expect(await descriptorObject?.json()).toEqual({
+      mediaType: artifactManifestOne.mediaType,
+      digest: firstArtifactDigest,
+      size: manifestSize(artifactManifestOne),
+      artifactType,
+      annotations: artifactManifestOne.annotations,
+    });
+
+    const firstPage = await getReferrersIndex(name, subjectDigest, new URLSearchParams({ n: "1" }));
+    expect(firstPage.response.headers.get("content-type")).toEqual("application/vnd.oci.image.index.v1+json");
+    expect(firstPage.body.schemaVersion).toEqual(2);
+    expect(firstPage.body.mediaType).toEqual("application/vnd.oci.image.index.v1+json");
+    expect(firstPage.body.manifests).toHaveLength(1);
+    expect(firstPage.response.headers.get("Link")).toMatch(/^<.*>; rel="next"$/);
+
+    const nextURL = parseLinkHeaderURL(firstPage.response.headers.get("Link")!);
+    const secondPage = await getReferrersIndex(name, subjectDigest, nextURL.searchParams);
+    expect(secondPage.body.manifests).toHaveLength(1);
+    expect(secondPage.response.headers.get("Link")).toBeNull();
+
+    const returnedDigests = new Set([firstPage.body.manifests[0].digest, secondPage.body.manifests[0].digest]);
+    expect(returnedDigests).toEqual(new Set([firstArtifactDigest, secondArtifactDigest]));
+  });
+
+  test("GET /v2/:name/referrers/:digest filters descriptors and returns empty results", async () => {
+    const name = "referrers-filter";
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const subjectDescriptor = {
+      mediaType: subjectManifest.mediaType,
+      digest: subjectDigest,
+      size: manifestSize(subjectManifest),
+    };
+
+    const explicitArtifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const derivedArtifactType = "application/vnd.cloudchamber.chain.config.v1+json";
+    const explicitArtifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: explicitArtifactType,
+      subject: subjectDescriptor,
+    } satisfies ManifestSchema;
+    const derivedArtifactBase = getImageManifestV2(await generateManifest(name));
+    const derivedArtifactManifest = {
+      ...derivedArtifactBase,
+      config: {
+        ...derivedArtifactBase.config,
+        mediaType: derivedArtifactType,
+      },
+      subject: subjectDescriptor,
+    } satisfies ManifestSchema;
+
+    const { sha256: explicitArtifactDigest } = await createManifest(name, explicitArtifactManifest);
+    const { sha256: derivedArtifactDigest } = await createManifest(name, derivedArtifactManifest);
+
+    const explicitResult = await getReferrersIndex(
+      name,
+      subjectDigest,
+      new URLSearchParams({ artifactType: explicitArtifactType }),
+    );
+    expect(explicitResult.response.headers.get("OCI-Filters-Applied")).toEqual("artifactType");
+    expect(explicitResult.body.manifests.map((manifest) => manifest.digest)).toEqual([explicitArtifactDigest]);
+
+    const derivedResult = await getReferrersIndex(
+      name,
+      subjectDigest,
+      new URLSearchParams({ artifactType: derivedArtifactType }),
+    );
+    expect(derivedResult.body.manifests.map((manifest) => manifest.digest)).toEqual([derivedArtifactDigest]);
+    expect(derivedResult.body.manifests[0].artifactType).toEqual(derivedArtifactType);
+
+    const emptyResult = await getReferrersIndex(
+      name,
+      subjectDigest,
+      new URLSearchParams({ artifactType: "application/vnd.cloudchamber.missing.v1" }),
+    );
+    expect(emptyResult.response.headers.get("OCI-Filters-Applied")).toEqual("artifactType");
+    expect(emptyResult.body.manifests).toEqual([]);
+  });
+
+  test("GET /v2/:name/referrers/:digest paginates filtered results across storage pages", async () => {
+    const name = "referrers-filter-pagination";
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const matchingArtifactType = "application/vnd.cloudchamber.match.v1";
+    const otherArtifactType = "application/vnd.cloudchamber.other.v1";
+
+    await seedReferrerIndex(
+      name,
+      subjectDigest,
+      Array.from({ length: 122 }, (_, index) => {
+        return {
+          mediaType: "application/vnd.oci.image.manifest.v1+json",
+          digest: numberedDigest(index),
+          size: index + 1,
+          artifactType: index % 2 === 0 ? matchingArtifactType : otherArtifactType,
+        } satisfies ReferrerDescriptor;
+      }),
+    );
+
+    const firstPage = await getReferrersIndex(
+      name,
+      subjectDigest,
+      new URLSearchParams({ artifactType: matchingArtifactType, n: "60" }),
+    );
+    expect(firstPage.body.manifests).toHaveLength(60);
+    expect(firstPage.response.headers.get("Link")).toMatch(/^<.*>; rel="next"$/);
+
+    const nextURL = parseLinkHeaderURL(firstPage.response.headers.get("Link")!);
+    expect(nextURL.searchParams.get("artifactType")).toEqual(matchingArtifactType);
+    expect(nextURL.searchParams.get("n")).toEqual("60");
+
+    const secondPage = await getReferrersIndex(name, subjectDigest, nextURL.searchParams);
+    expect(secondPage.body.manifests).toEqual([
+      {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: numberedDigest(120),
+        size: 121,
+        artifactType: matchingArtifactType,
+      },
+    ]);
+    expect(secondPage.response.headers.get("Link")).toBeNull();
+  });
+
+  test("GET /v2/:name/referrers/:digest ignores invalid native descriptor entries", async () => {
+    const name = "referrers-invalid-native-entry";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await createManifest(name, artifactManifest);
+    await bindings.REGISTRY.put(`${name}/_referrers/${subjectDigest}/${numberedDigest(3000)}`, "{", {
+      httpMetadata: { contentType: "application/json" },
+    });
+    await bindings.REGISTRY.put(
+      `${name}/_referrers/${subjectDigest}/${numberedDigest(3001)}`,
+      JSON.stringify({
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: numberedDigest(3002),
+        size: 1,
+      }),
+      {
+        httpMetadata: { contentType: "application/json" },
+      },
+    );
+    await bindings.REGISTRY.put(
+      `${name}/_referrers/${subjectDigest}/${numberedDigest(3003)}`,
+      JSON.stringify({
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: numberedDigest(3003),
+        size: -1,
+      }),
+      {
+        httpMetadata: { contentType: "application/json" },
+      },
+    );
+
+    const referrers = await getReferrersIndex(name, subjectDigest);
+    expect(referrers.body.manifests).toEqual([
+      {
+        mediaType: artifactManifest.mediaType,
+        digest: artifactDigest,
+        size: manifestSize(artifactManifest),
+        artifactType: artifactManifest.artifactType,
+        annotations: artifactManifest.annotations,
+      },
+    ]);
+  });
+
+  test("subject-bearing OCI indexes are indexed and cleaned up", async () => {
+    const name = "referrers-index-artifact";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+
+    const childManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: childDigest } = await createManifest(name, childManifest, "child");
+
+    const artifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const artifactIndex = {
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.index.v1+json",
+      artifactType,
+      annotations: {
+        "org.opencontainers.image.title": "chain-index",
+      },
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+      manifests: [
+        {
+          mediaType: childManifest.mediaType,
+          digest: childDigest,
+          size: manifestSize(childManifest),
+          annotations: {
+            "org.opencontainers.image.ref.name": "child",
+          },
+          urls: ["https://example.invalid/referrer-child"],
+        },
+      ],
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest, response } = await uploadManifest(name, artifactIndex, "artifact-index");
+    expect(response.headers.get("oci-subject")).toEqual(subjectDigest);
+
+    const descriptorObject = await bindings.REGISTRY.get(`${name}/_referrers/${subjectDigest}/${artifactDigest}`);
+    expect(descriptorObject).not.toBeNull();
+    expect(await descriptorObject?.json()).toEqual({
+      mediaType: artifactIndex.mediaType,
+      digest: artifactDigest,
+      size: manifestSize(artifactIndex),
+      artifactType,
+      annotations: artifactIndex.annotations,
+    });
+
+    const referrers = await getReferrersIndex(name, subjectDigest, new URLSearchParams({ artifactType }));
+    expect(referrers.body.manifests).toEqual([
+      {
+        mediaType: artifactIndex.mediaType,
+        digest: artifactDigest,
+        size: manifestSize(artifactIndex),
+        artifactType,
+        annotations: artifactIndex.annotations,
+      },
+    ]);
+
+    const digestDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/${artifactDigest}`, null));
+    expect(digestDeleteResponse.status).toEqual(202);
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeNull();
+  });
+
+  test("DELETE manifest digest cleans up referrer entries", async () => {
+    const name = "referrers-delete";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await createManifest(name, artifactManifest, "artifact");
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeTruthy();
+
+    const tagDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/artifact`, null));
+    expect(tagDeleteResponse.status).toEqual(202);
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeTruthy();
+
+    const digestDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/${artifactDigest}`, null));
+    expect(digestDeleteResponse.status).toEqual(202);
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeNull();
+
+    const referrers = await getReferrersIndex(name, subjectDigest);
+    expect(referrers.body.manifests).toEqual([]);
+  });
+
+  test("DELETE manifest digest paginates tag cleanup before removing referrer entries", async () => {
+    const name = "referrers-delete-pagination";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const aliases = ["zz-artifact-a", "zz-artifact-b", "zz-artifact-c"];
+    let artifactDigest = "";
+    for (const alias of aliases) {
+      const { sha256 } = await createManifest(name, artifactManifest, alias);
+      artifactDigest = sha256;
+    }
+
+    let deletePath = `/v2/${name}/manifests/${artifactDigest}?limit=1`;
+    let attempts = 0;
+    while (true) {
+      attempts++;
+      const response = await fetch(createRequest("DELETE", deletePath, null));
+      if (response.status === 202) {
+        break;
+      }
+
+      expect(response.status).toEqual(400);
+      expect(response.headers.get("Link")).toMatch(/^<.*>; rel="next"$/);
+      expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeTruthy();
+      expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeTruthy();
+
+      const nextURL = parseLinkHeaderURL(response.headers.get("Link")!);
+      deletePath = `${nextURL.pathname}${nextURL.search}`;
+    }
+
+    expect(attempts).toBeGreaterThan(1);
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeNull();
+    for (const alias of aliases) {
+      expect(await bindings.REGISTRY.head(`${name}/manifests/${alias}`)).toBeNull();
+    }
+  });
+
+  test("DELETE manifest digest rejects invalid pagination limits", async () => {
+    const name = "referrers-delete-invalid-limit";
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+    const { sha256: artifactDigest } = await createManifest(name, artifactManifest, "artifact");
+
+    const response = await fetch(createRequest("DELETE", `/v2/${name}/manifests/${artifactDigest}?limit=0`, null));
+    expect(response.status).toEqual(400);
+  });
+
+  test("PUT retagging a referrer keeps prior digests discoverable while they still exist", async () => {
+    const name = "referrers-retag";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const firstArtifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      annotations: {
+        "org.opencontainers.image.title": "chain-one",
+      },
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+    const secondArtifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      annotations: {
+        "org.opencontainers.image.title": "chain-two",
+      },
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { sha256: firstArtifactDigest } = await createManifest(name, firstArtifactManifest, "artifact");
+    const { sha256: secondArtifactDigest } = await createManifest(name, secondArtifactManifest, "artifact");
+
+    expect(firstArtifactDigest).not.toEqual(secondArtifactDigest);
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${firstArtifactDigest}`)).toBeTruthy();
+
+    const referrers = await getReferrersIndex(name, subjectDigest);
+    expect(new Set(referrers.body.manifests.map((manifest) => manifest.digest))).toEqual(
+      new Set([firstArtifactDigest, secondArtifactDigest]),
+    );
+
+    await runGarbageCollector(name, "untagged");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${firstArtifactDigest}`)).toBeTruthy();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${secondArtifactDigest}`)).toBeTruthy();
+  });
+
+  test("DELETE manifest digest cleans up referrer entries for legacy subject metadata", async () => {
+    const name = "referrers-delete-legacy";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await createManifest(name, artifactManifest, "artifact");
+    const artifactText = JSON.stringify(artifactManifest);
+    await bindings.REGISTRY.put(`${name}/manifests/${artifactDigest}`, artifactText, {
+      httpMetadata: { contentType: "application/gzip" },
+      sha256: artifactDigest.slice(SHA256_PREFIX_LEN),
+    });
+
+    const digestDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/${artifactDigest}`, null));
+    expect(digestDeleteResponse.status).toEqual(202);
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeNull();
+  });
+
+  test("GC keeps live subject referrers and prunes them after subject removal", async () => {
+    const name = "referrers-gc";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await createManifest(name, artifactManifest);
+
+    await runGarbageCollector(name, "both");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeTruthy();
+
+    const subjectDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/${subjectDigest}`, null));
+    expect(subjectDeleteResponse.status).toEqual(202);
+
+    expect((await bindings.REGISTRY.list({ prefix: `${name}/_referrers/${subjectDigest}/` })).objects).toHaveLength(1);
+    expect((await getReferrersIndex(name, subjectDigest)).body.manifests).toEqual([
+      {
+        mediaType: artifactManifest.mediaType,
+        digest: artifactDigest,
+        size: manifestSize(artifactManifest),
+        artifactType: artifactManifest.artifactType,
+        annotations: artifactManifest.annotations,
+      },
+    ]);
+
+    await runGarbageCollector(name, "both");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeNull();
+
+    const referrers = await getReferrersIndex(name, subjectDigest);
+    expect(referrers.body.manifests).toEqual([]);
+  });
+
+  test("untagged GC keeps tagged referrers indexed after subject removal", async () => {
+    const name = "referrers-gc-tagged-referrer";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      annotations: {
+        "org.opencontainers.image.title": "tagged-referrer",
+      },
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await createManifest(name, artifactManifest, "artifact");
+
+    const subjectTagDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/latest`, null));
+    expect(subjectTagDeleteResponse.status).toEqual(202);
+
+    await runGarbageCollector(name, "untagged");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${subjectDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeTruthy();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/artifact`)).toBeTruthy();
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeTruthy();
+
+    const referrers = await getReferrersIndex(name, subjectDigest);
+    expect(referrers.body.manifests).toEqual([
+      {
+        mediaType: artifactManifest.mediaType,
+        digest: artifactDigest,
+        size: manifestSize(artifactManifest),
+        artifactType: artifactManifest.artifactType,
+        annotations: artifactManifest.annotations,
+      },
+    ]);
+  });
+
+  test("GC keeps child manifests of live referrer OCI indexes", async () => {
+    const name = "referrers-gc-index-children";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const childManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: childDigest } = await createManifest(name, childManifest);
+    const artifactIndex = {
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.index.v1+json",
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+      manifests: [
+        {
+          mediaType: childManifest.mediaType,
+          digest: childDigest,
+          size: manifestSize(childManifest),
+        },
+      ],
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await createManifest(name, artifactIndex);
+
+    await runGarbageCollector(name, "untagged");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeTruthy();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${childDigest}`)).toBeTruthy();
+
+    const subjectTagDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/latest`, null));
+    expect(subjectTagDeleteResponse.status).toEqual(202);
+
+    await runGarbageCollector(name, "untagged");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${subjectDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${childDigest}`)).toBeNull();
+  });
+
+  test("untagged GC removes referrers whose subjects are pruned in the same pass", async () => {
+    const name = "referrers-gc-untagged";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await createManifest(name, artifactManifest);
+
+    const subjectTagDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/latest`, null));
+    expect(subjectTagDeleteResponse.status).toEqual(202);
+
+    await runGarbageCollector(name, "untagged");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${subjectDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${subjectDigest}/${artifactDigest}`)).toBeNull();
+
+    const referrers = await getReferrersIndex(name, subjectDigest);
+    expect(referrers.body.manifests).toEqual([]);
+  });
+
+  test("PUT /v2/:name/manifests/:reference rejects invalid subject digests", async () => {
+    const name = "referrers-invalid-subject";
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: "sha256/not-a-digest",
+        size: 123,
+      },
+    } satisfies ManifestSchema;
+
+    const response = await fetch(
+      createRequest("PUT", `/v2/${name}/manifests/artifact`, new Blob([JSON.stringify(artifactManifest)]).stream(), {
+        "Content-Type": "application/gzip",
+      }),
+    );
+    expect(response.status).toEqual(400);
+  });
+
+  test("PUT /v2/:name/manifests/:reference rejects missing local subjects", async () => {
+    const name = "referrers-missing-subject";
+    const bindings = env as Env;
+    const missingSubjectDigest = numberedDigest(4500);
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: missingSubjectDigest,
+        size: 123,
+      },
+    } satisfies ManifestSchema;
+    const artifactDigest = await getSHA256(JSON.stringify(artifactManifest));
+
+    const response = await fetch(
+      createRequest("PUT", `/v2/${name}/manifests/artifact`, new Blob([JSON.stringify(artifactManifest)]).stream(), {
+        "Content-Type": "application/gzip",
+      }),
+    );
+
+    expect(response.status).toEqual(400);
+    expect((await response.json()) as { errors: { code: string; message: string }[] }).toEqual({
+      errors: [expect.objectContaining({ code: "BLOB_UNKNOWN", message: `unknown subject ${missingSubjectDigest}` })],
+    });
+    expect(await bindings.REGISTRY.head(`${name}/manifests/artifact`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/_referrers/${missingSubjectDigest}/${artifactDigest}`)).toBeNull();
+  });
+
+  test("PUT /v2/:name/manifests/:reference rejects invalid subject-bearing OCI indexes", async () => {
+    const name = "referrers-invalid-index";
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const invalidIndex = {
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.index.v1+json",
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+      manifests: [
+        {
+          mediaType: "application/vnd.oci.image.manifest.v1+json",
+          digest: numberedDigest(4000),
+          size: "not-a-number",
+        },
+      ],
+    };
+
+    const response = await fetch(
+      createRequest("PUT", `/v2/${name}/manifests/invalid-index`, new Blob([JSON.stringify(invalidIndex)]).stream(), {
+        "Content-Type": "application/vnd.oci.image.index.v1+json",
+      }),
+    );
+    expect(response.status).toEqual(400);
+    expect((await response.json()) as { errors: { code: string }[] }).toEqual({
+      errors: [expect.objectContaining({ code: "MANIFEST_INVALID" })],
+    });
+  });
+
+  test("GET /v2/:name/referrers/:digest accepts OCI digest syntax", async () => {
+    const name = "referrers-digest-syntax";
+    const subjectDigest = "sha512.b64:AbCdEf0123_-=";
+
+    await seedReferrerIndex(name, subjectDigest, [
+      {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: numberedDigest(1),
+        size: 1,
+      },
+    ]);
+
+    const response = await fetch(createRequest("GET", `/v2/${name}/referrers/${subjectDigest}`, null));
+    expect(response.status).toEqual(200);
+    expect(((await response.json()) as ReferrersIndex).manifests).toHaveLength(1);
+  });
+
+  test("GET /v2/:name/referrers/:digest rejects invalid digests and pagination params", async () => {
+    const validDigest = numberedDigest(9999);
+    const uppercaseDigest = `sha256:${"A".repeat(64)}`;
+
+    const invalidDigestResponse = await fetch(
+      createRequest("GET", "/v2/referrers-invalid/referrers/not-a-digest", null),
+    );
+    expect(invalidDigestResponse.status).toEqual(400);
+
+    const uppercaseDigestResponse = await fetch(
+      createRequest("GET", `/v2/referrers-invalid/referrers/${uppercaseDigest}`, null),
+    );
+    expect(uppercaseDigestResponse.status).toEqual(400);
+
+    const zeroLimitResponse = await fetch(
+      createRequest("GET", `/v2/referrers-invalid/referrers/${validDigest}?n=0`, null),
+    );
+    expect(zeroLimitResponse.status).toEqual(400);
+
+    const fractionalLimitResponse = await fetch(
+      createRequest("GET", `/v2/referrers-invalid/referrers/${validDigest}?n=1.5`, null),
+    );
+    expect(fractionalLimitResponse.status).toEqual(400);
+
+    const oversizedLimitResponse = await fetch(
+      createRequest("GET", `/v2/referrers-invalid/referrers/${validDigest}?n=1001`, null),
+    );
+    expect(oversizedLimitResponse.status).toEqual(400);
+
+    const invalidLastResponse = await fetch(
+      createRequest("GET", `/v2/referrers-invalid/referrers/${validDigest}?last=not-a-digest`, null),
+    );
+    expect(invalidLastResponse.status).toEqual(400);
   });
 });
 
@@ -607,9 +1408,9 @@ describe("http client", () => {
     envBindings.PASSWORD = "world";
     envBindings.USERNAME = "hello";
     envBindings.REGISTRIES_JSON = undefined;
-    global.fetch = async function (r: RequestInfo): Promise<Response> {
-      return fetch(new Request(r));
-    };
+    global.fetch = (async (input: Parameters<typeof global.fetch>[0], init?: Parameters<typeof global.fetch>[1]) => {
+      return fetch(new Request(input as string | URL | Request, init));
+    }) as typeof global.fetch;
     const client = new RegistryHTTPClient(envBindings, {
       registry: "https://localhost",
       password_env: "PASSWORD",
@@ -631,9 +1432,9 @@ describe("http client", () => {
     envBindings.READONLY_PASSWORD = "world";
     envBindings.READONLY_USERNAME = "hello";
     envBindings.REGISTRIES_JSON = undefined;
-    global.fetch = async function (r: RequestInfo): Promise<Response> {
-      return fetch(new Request(r));
-    };
+    global.fetch = (async (input: Parameters<typeof global.fetch>[0], init?: Parameters<typeof global.fetch>[1]) => {
+      return fetch(new Request(input as string | URL | Request, init));
+    }) as typeof global.fetch;
     const client = new RegistryHTTPClient(envBindings, {
       registry: "https://localhost",
       password_env: "PASSWORD",
@@ -645,6 +1446,394 @@ describe("http client", () => {
     }
 
     expect("exists" in res && res.exists).toBe(false);
+  });
+
+  test("test list referrers", async () => {
+    const name = "http-client-referrers";
+    const subjectDigest = numberedDigest(9997);
+    const artifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const firstArtifactDigest = numberedDigest(9998);
+    const secondArtifactDigest = numberedDigest(9999);
+    const firstDescriptor = {
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      digest: firstArtifactDigest,
+      size: 123,
+      artifactType,
+      annotations: {
+        "org.opencontainers.image.title": "http-client-one",
+      },
+    } satisfies ReferrerDescriptor;
+    const secondDescriptor = {
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      digest: secondArtifactDigest,
+      size: 456,
+      artifactType,
+      annotations: {
+        "org.opencontainers.image.title": "http-client-two",
+      },
+    } satisfies ReferrerDescriptor;
+
+    envBindings = { ...bindings };
+    envBindings.JWT_REGISTRY_TOKENS_PUBLIC_KEY = "";
+    envBindings.PASSWORD = "world";
+    envBindings.USERNAME = "hello";
+    envBindings.REGISTRIES_JSON = undefined;
+    let referrersRequests = 0;
+    global.fetch = (async (input: Parameters<typeof global.fetch>[0], init?: Parameters<typeof global.fetch>[1]) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      expect(url.pathname).toEqual(`/v2/${name}/referrers/${subjectDigest}`);
+
+      referrersRequests++;
+      if (referrersRequests === 1) {
+        expect(url.searchParams.get("artifactType")).toEqual(artifactType);
+        expect(url.searchParams.get("n")).toEqual("1");
+        expect(url.searchParams.get("last")).toBeNull();
+        const firstResponse = new Response(
+          JSON.stringify({
+            schemaVersion: 2,
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            manifests: [firstDescriptor],
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/vnd.oci.image.index.v1+json",
+              "Link": `</v2/${name}/referrers/${subjectDigest}?page=2>; rel="next"`,
+            },
+          },
+        );
+        Object.defineProperty(firstResponse, "url", {
+          value: `https://localhost/v2/${name}/referrers/${subjectDigest}?artifactType=${encodeURIComponent(
+            artifactType,
+          )}&n=1`,
+        });
+        return firstResponse;
+      }
+
+      expect(url.searchParams.get("page")).toEqual("2");
+      return new Response(
+        JSON.stringify({
+          schemaVersion: 2,
+          mediaType: "application/vnd.oci.image.index.v1+json",
+          manifests: [secondDescriptor],
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/vnd.oci.image.index.v1+json",
+          },
+        },
+      );
+    }) as typeof global.fetch;
+    const client = new RegistryHTTPClient(envBindings, {
+      registry: "https://localhost",
+      password_env: "PASSWORD",
+      username,
+    });
+
+    const firstPage = await client.listReferrers(name, subjectDigest, { artifactType, limit: 1 });
+    if ("response" in firstPage) {
+      expect(await firstPage.response.json()).toEqual({ status: firstPage.response.status });
+      throw new Error("expected listReferrers to succeed");
+    }
+
+    expect(firstPage.cursor).toEqual(`/v2/${name}/referrers/${subjectDigest}?page=2`);
+    expect(firstPage.manifests).toEqual([firstDescriptor]);
+
+    const secondPage = await client.listReferrers(name, subjectDigest, {
+      artifactType,
+      limit: 1,
+      last: firstPage.cursor,
+    });
+    if ("response" in secondPage) {
+      expect(await secondPage.response.json()).toEqual({ status: secondPage.response.status });
+      throw new Error("expected paginated listReferrers to succeed");
+    }
+
+    expect(secondPage.cursor).toBeUndefined();
+    expect(secondPage.manifests).toEqual([secondDescriptor]);
+    expect(new Set([firstPage.manifests[0].digest, secondPage.manifests[0].digest])).toEqual(
+      new Set([firstArtifactDigest, secondArtifactDigest]),
+    );
+  });
+
+  test("test list referrers selects rel next from multi-link headers", async () => {
+    const name = "http-client-referrers-multilink";
+    const subjectDigest = numberedDigest(9970);
+    const firstDescriptor = {
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      digest: numberedDigest(9971),
+      size: 11,
+    } satisfies ReferrerDescriptor;
+    const secondDescriptor = {
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      digest: numberedDigest(9972),
+      size: 22,
+    } satisfies ReferrerDescriptor;
+
+    envBindings = { ...bindings };
+    envBindings.JWT_REGISTRY_TOKENS_PUBLIC_KEY = "";
+    envBindings.PASSWORD = "world";
+    envBindings.USERNAME = "hello";
+    envBindings.REGISTRIES_JSON = undefined;
+    let referrersRequests = 0;
+    global.fetch = (async (input: Parameters<typeof global.fetch>[0], init?: Parameters<typeof global.fetch>[1]) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      expect(url.pathname).toEqual(`/v2/${name}/referrers/${subjectDigest}`);
+      referrersRequests++;
+      if (referrersRequests === 1) {
+        const firstResponse = new Response(
+          JSON.stringify({
+            schemaVersion: 2,
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            manifests: [firstDescriptor],
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/vnd.oci.image.index.v1+json",
+              "Link": `</v2/${name}/tags/list?n=1>; rel="alternate", </v2/${name}/referrers/${subjectDigest}?page=2>; rel="next"`,
+            },
+          },
+        );
+        Object.defineProperty(firstResponse, "url", {
+          value: `https://localhost/v2/${name}/referrers/${subjectDigest}`,
+        });
+        return firstResponse;
+      }
+
+      expect(url.searchParams.get("page")).toEqual("2");
+      return new Response(
+        JSON.stringify({
+          schemaVersion: 2,
+          mediaType: "application/vnd.oci.image.index.v1+json",
+          manifests: [secondDescriptor],
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/vnd.oci.image.index.v1+json",
+          },
+        },
+      );
+    }) as typeof global.fetch;
+
+    const client = new RegistryHTTPClient(envBindings, {
+      registry: "https://localhost",
+      password_env: "PASSWORD",
+      username,
+    });
+
+    const firstPage = await client.listReferrers(name, subjectDigest, { limit: 1 });
+    if ("response" in firstPage) {
+      expect(await firstPage.response.json()).toEqual({ status: firstPage.response.status });
+      throw new Error("expected multi-link listReferrers to succeed");
+    }
+
+    expect(firstPage.cursor).toEqual(`/v2/${name}/referrers/${subjectDigest}?page=2`);
+
+    const secondPage = await client.listReferrers(name, subjectDigest, { limit: 1, last: firstPage.cursor });
+    if ("response" in secondPage) {
+      expect(await secondPage.response.json()).toEqual({ status: secondPage.response.status });
+      throw new Error("expected paginated multi-link listReferrers to succeed");
+    }
+
+    expect(secondPage.manifests).toEqual([secondDescriptor]);
+  });
+
+  test("test list referrers ignores same-origin next links for different paths", async () => {
+    const name = "http-client-referrers-wrong-path";
+    const subjectDigest = numberedDigest(9960);
+    const descriptor = {
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      digest: numberedDigest(9961),
+      size: 333,
+    } satisfies ReferrerDescriptor;
+
+    envBindings = { ...bindings };
+    envBindings.JWT_REGISTRY_TOKENS_PUBLIC_KEY = "";
+    envBindings.PASSWORD = "world";
+    envBindings.USERNAME = "hello";
+    envBindings.REGISTRIES_JSON = undefined;
+    global.fetch = (async (input: Parameters<typeof global.fetch>[0], init?: Parameters<typeof global.fetch>[1]) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      const response = new Response(
+        JSON.stringify({
+          schemaVersion: 2,
+          mediaType: "application/vnd.oci.image.index.v1+json",
+          manifests: [descriptor],
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/vnd.oci.image.index.v1+json",
+            "Link": `</v2/${name}/tags/list?n=1>; rel="next"`,
+          },
+        },
+      );
+      Object.defineProperty(response, "url", {
+        value: `https://localhost/v2/${name}/referrers/${subjectDigest}`,
+      });
+      return response;
+    }) as typeof global.fetch;
+
+    const client = new RegistryHTTPClient(envBindings, {
+      registry: "https://localhost",
+      password_env: "PASSWORD",
+      username,
+    });
+
+    const res = await client.listReferrers(name, subjectDigest);
+    if ("response" in res) {
+      expect(await res.response.json()).toEqual({ status: res.response.status });
+      throw new Error("expected listReferrers to ignore wrong-path next links");
+    }
+
+    expect(res.cursor).toBeUndefined();
+    expect(res.manifests).toEqual([descriptor]);
+  });
+
+  test("test list referrers does not fall back after an opaque next-link 404", async () => {
+    const name = "http-client-referrers-opaque-404";
+    const subjectDigest = numberedDigest(9980);
+    const descriptor = {
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      digest: numberedDigest(9981),
+      size: 111,
+    } satisfies ReferrerDescriptor;
+
+    envBindings = { ...bindings };
+    envBindings.JWT_REGISTRY_TOKENS_PUBLIC_KEY = "";
+    envBindings.PASSWORD = "world";
+    envBindings.USERNAME = "hello";
+    envBindings.REGISTRIES_JSON = undefined;
+    let referrersRequests = 0;
+    global.fetch = (async (input: Parameters<typeof global.fetch>[0], init?: Parameters<typeof global.fetch>[1]) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      expect(url.pathname).toEqual(`/v2/${name}/referrers/${subjectDigest}`);
+      referrersRequests++;
+      if (referrersRequests === 1) {
+        const firstResponse = new Response(
+          JSON.stringify({
+            schemaVersion: 2,
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            manifests: [descriptor],
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/vnd.oci.image.index.v1+json",
+              "Link": `</v2/${name}/referrers/${subjectDigest}?page=2>; rel="next"`,
+            },
+          },
+        );
+        Object.defineProperty(firstResponse, "url", {
+          value: `https://localhost/v2/${name}/referrers/${subjectDigest}`,
+        });
+        return firstResponse;
+      }
+
+      expect(url.searchParams.get("page")).toEqual("2");
+      return new Response(JSON.stringify({ status: 404 }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof global.fetch;
+
+    const client = new RegistryHTTPClient(envBindings, {
+      registry: "https://localhost",
+      password_env: "PASSWORD",
+      username,
+    });
+
+    const firstPage = await client.listReferrers(name, subjectDigest, { limit: 1 });
+    if ("response" in firstPage) {
+      expect(await firstPage.response.json()).toEqual({ status: firstPage.response.status });
+      throw new Error("expected the initial opaque pagination request to succeed");
+    }
+
+    const secondPage = await client.listReferrers(name, subjectDigest, { limit: 1, last: firstPage.cursor });
+    expect("response" in secondPage).toBeTruthy();
+    if ("response" in secondPage) {
+      expect(secondPage.response.status).toEqual(404);
+    }
+  });
+
+  test("test list referrers ignores cross-origin next links", async () => {
+    const name = "http-client-referrers-xorigin";
+    const subjectDigest = numberedDigest(9010);
+    const descriptor = {
+      mediaType: "application/vnd.oci.image.manifest.v1+json",
+      digest: numberedDigest(9011),
+      size: 654,
+    } satisfies ReferrerDescriptor;
+
+    envBindings = { ...bindings };
+    envBindings.JWT_REGISTRY_TOKENS_PUBLIC_KEY = "";
+    envBindings.PASSWORD = "world";
+    envBindings.USERNAME = "hello";
+    envBindings.REGISTRIES_JSON = undefined;
+    global.fetch = (async (input: Parameters<typeof global.fetch>[0], init?: Parameters<typeof global.fetch>[1]) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      const response = new Response(
+        JSON.stringify({
+          schemaVersion: 2,
+          mediaType: "application/vnd.oci.image.index.v1+json",
+          manifests: [descriptor],
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/vnd.oci.image.index.v1+json",
+            "Link": `<https://attacker.example/v2/${name}/referrers/${subjectDigest}?page=2>; rel="next"`,
+          },
+        },
+      );
+      Object.defineProperty(response, "url", {
+        value: `https://localhost/v2/${name}/referrers/${subjectDigest}`,
+      });
+      return response;
+    }) as typeof global.fetch;
+
+    const client = new RegistryHTTPClient(envBindings, {
+      registry: "https://localhost",
+      password_env: "PASSWORD",
+      username,
+    });
+
+    const res = await client.listReferrers(name, subjectDigest);
+    if ("response" in res) {
+      expect(await res.response.json()).toEqual({ status: res.response.status });
+      throw new Error("expected listReferrers to ignore unsafe next links");
+    }
+
+    expect(res.cursor).toBeUndefined();
+    expect(res.manifests).toEqual([descriptor]);
   });
 });
 
@@ -680,7 +1869,7 @@ describe("push and catalog", () => {
       expect(body.repositories).toHaveLength(1);
 
       repositoryBuildUp.push(...body.repositories);
-      const url = new URL(response.headers.get("Link")!.split(";")[0].trim());
+      const url = parseLinkHeaderURL(response.headers.get("Link")!);
       currentPath = url.pathname + url.search;
     }
 
@@ -733,7 +1922,7 @@ describe("push and catalog", () => {
       expect(body.repositories).toHaveLength(1);
 
       repositoryBuildUp.push(...body.repositories);
-      const url = new URL(response.headers.get("Link")!.split(";")[0].trim());
+      const url = parseLinkHeaderURL(response.headers.get("Link")!);
       currentPath = url.pathname + url.search;
     }
 
@@ -753,6 +1942,29 @@ describe("push and catalog", () => {
       const listObjects = await bindings.REGISTRY.list({ prefix: "hello/hello/blobs/" });
       expect(listObjects.objects.length).toEqual(1);
     }
+  });
+
+  test("catalog ignores referrer index entries", async () => {
+    const name = "catalog-referrers";
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+    await createManifest(name, artifactManifest, "artifact");
+
+    const response = await fetch(createRequest("GET", "/v2/_catalog?n=1000", null));
+    expect(response.ok).toBeTruthy();
+    const body = (await response.json()) as { repositories: string[] };
+
+    expect(body.repositories).toContain(name);
+    expect(body.repositories.filter((repository) => repository.startsWith(`${name}/_referrers`))).toEqual([]);
   });
 });
 
@@ -805,6 +2017,40 @@ describe("v2 manifest-list", () => {
     for (const digest of manifestsSha256) {
       expect(await bindings.REGISTRY.head(`${name}/manifests/${digest}`)).toBeNull();
     }
+  });
+
+  test("Reject docker manifest-list descriptors without platform", async () => {
+    const name = "m-arch-invalid";
+    const amdManifest = await generateManifest(name);
+    const armManifest = await generateManifest(name);
+    const { sha256: amdSha256 } = await createManifest(name, amdManifest);
+    const { sha256: armSha256 } = await createManifest(name, armManifest);
+    const invalidManifestList = {
+      schemaVersion: 2,
+      mediaType: "application/vnd.docker.distribution.manifest.list.v2+json",
+      manifests: [
+        {
+          mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+          size: JSON.stringify(amdManifest).length,
+          digest: amdSha256,
+        },
+        {
+          mediaType: "application/vnd.docker.distribution.manifest.v2+json",
+          size: JSON.stringify(armManifest).length,
+          digest: armSha256,
+        },
+      ],
+    };
+
+    const response = await fetch(
+      createRequest("PUT", `/v2/${name}/manifests/app`, new Blob([JSON.stringify(invalidManifestList)]).stream(), {
+        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json",
+      }),
+    );
+    expect(response.status).toEqual(400);
+    expect((await response.json()) as { errors: { code: string }[] }).toEqual({
+      errors: [expect.objectContaining({ code: "MANIFEST_INVALID" })],
+    });
   });
 
   test("Upload manifest-list with layer mounting", async () => {


### PR DESCRIPTION
Add support for referrers API to allow the registry to support image-linked objects. Includes support for indexing/listing/deleting and GC.