### PR TITLE
Enforce btrfs singleton referrers

### DIFF
--- a/src/registry/garbage-collector.ts
+++ b/src/registry/garbage-collector.ts
@@ -5,7 +5,12 @@
 
 import { ManifestSchema } from "../manifest";
 import { hexToDigest } from "../user";
-import { symlinkHeader } from "./r2";
+import {
+  cloudchamberBtrfsChainArtifactType,
+  parseCloudchamberSingletonReferrerRecord,
+  singletonReferrerRecordsPrefix,
+  symlinkHeader,
+} from "./r2";
 
 export type GarbageCollectionMode = "unreferenced" | "untagged";
 export type GCOptions = {
@@ -205,6 +210,7 @@ export class GarbageCollector {
       const referrerIndexByDigest = new Map<string, string[]>();
       const referrerIndexBySubject = new Map<string, Array<{ key: string; referrerDigest: string }>>();
       const referrerDigestsBySubject = new Map<string, Set<string>>();
+      const singletonReferrerDigests = new Set<string>();
       const manifestHasTag = (manifests: Set<string>) => {
         return [...manifests].some((item) => !item.split("/").pop()?.startsWith("sha256:"));
       };
@@ -231,6 +237,25 @@ export class GarbageCollector {
         referrerDigestsBySubject.set(subjectDigest, referrerDigests);
         return true;
       });
+      await this.list(singletonReferrerRecordsPrefix(options.name), async (object) => {
+        const recordObject = await this.registry.get(object.key);
+        if (recordObject === null) {
+          return true;
+        }
+
+        let recordJSON: unknown;
+        try {
+          recordJSON = await recordObject.json();
+        } catch {
+          return true;
+        }
+
+        const record = parseCloudchamberSingletonReferrerRecord(recordJSON);
+        if (record?.repository === options.name && record.artifactType === cloudchamberBtrfsChainArtifactType) {
+          singletonReferrerDigests.add(record.digest);
+        }
+        return true;
+      });
 
       // Seed the live set from tagged manifests, then walk manifest indexes and referrer links.
       for (const [digest, manifests] of Object.entries(manifestList)) {
@@ -238,6 +263,7 @@ export class GarbageCollector {
           markManifestLive(digest);
         }
       }
+      singletonReferrerDigests.forEach(markManifestLive);
 
       while (pendingLiveManifests.length > 0) {
         const liveDigest = pendingLiveManifests.pop();

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -1,4 +1,5 @@
 import { Env } from "../..";
+import { encode } from "@cfworker/base64url";
 import jwt from "@tsndr/cloudflare-worker-jwt";
 import {
   MINIMUM_CHUNK,
@@ -11,7 +12,7 @@ import {
 } from "../chunk";
 import { InternalError, ManifestError, RangeError, ServerError } from "../errors";
 import { SHA256_PREFIX_LEN, getSHA256, hexToDigest, isValidDigest } from "../user";
-import { readableToBlob, readerToBlob, wrap } from "../utils";
+import { jsonHeaders, readableToBlob, readerToBlob, wrap } from "../utils";
 import { BlobUnknownError, ManifestUnknownError } from "../v2-errors";
 import {
   CheckLayerResponse,
@@ -33,6 +34,93 @@ import { GarbageCollectionMode, GarbageCollector } from "./garbage-collector";
 import { ManifestSchema, manifestSchema } from "../manifest";
 
 export const ociImageIndexContentType = "application/vnd.oci.image.index.v1+json";
+export const cloudchamberBtrfsChainArtifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+
+const cloudchamberSingletonReferrerRecordVersion = 1;
+
+export type CloudchamberSingletonReferrerRecord = {
+  version: 1;
+  repository: string;
+  subjectDigest: string;
+  artifactType: string;
+  digest: string;
+  descriptor: ReferrerDescriptor;
+  createdAtMs: number;
+};
+
+type SingletonConflictResponse = {
+  code: "SINGLETON_ARTIFACT_EXISTS";
+  subjectDigest: string;
+  artifactType: string;
+  committedDigest: string;
+};
+
+type SingletonCorruptResponse = {
+  code: "SINGLETON_ARTIFACT_CORRUPT";
+  subjectDigest: string;
+  artifactType: string;
+  reason: string;
+};
+
+export function singletonArtifactExistsResponse(
+  subjectDigest: string,
+  artifactType: string,
+  committedDigest: string,
+): Response {
+  const body: SingletonConflictResponse = {
+    code: "SINGLETON_ARTIFACT_EXISTS",
+    subjectDigest,
+    artifactType,
+    committedDigest,
+  };
+  return new Response(JSON.stringify(body), { status: 409, headers: jsonHeaders() });
+}
+
+export function singletonArtifactCorruptResponse(
+  subjectDigest: string,
+  artifactType: string,
+  reason: string,
+  status = 500,
+): Response {
+  const body: SingletonCorruptResponse = {
+    code: "SINGLETON_ARTIFACT_CORRUPT",
+    subjectDigest,
+    artifactType,
+    reason,
+  };
+  return new Response(JSON.stringify(body), { status, headers: jsonHeaders() });
+}
+
+function singletonArtifactExistsError(
+  subjectDigest: string,
+  artifactType: string,
+  committedDigest: string,
+): RegistryError {
+  return { response: singletonArtifactExistsResponse(subjectDigest, artifactType, committedDigest) };
+}
+
+function singletonArtifactCorruptError(
+  subjectDigest: string,
+  artifactType: string,
+  reason: string,
+  status?: number,
+): RegistryError {
+  return { response: singletonArtifactCorruptResponse(subjectDigest, artifactType, reason, status) };
+}
+
+export function isCloudchamberSingletonArtifactType(
+  artifactType: string | undefined,
+): artifactType is typeof cloudchamberBtrfsChainArtifactType {
+  return artifactType === cloudchamberBtrfsChainArtifactType;
+}
+
+export function singletonReferrerRecordsPrefix(name: string): string {
+  return `${name}/_cloudchamber/singletons/referrers/`;
+}
+
+export function singletonReferrerRecordPath(name: string, subjectDigest: string, artifactType: string): string {
+  return `${singletonReferrerRecordsPrefix(name)}${subjectDigest}/${encode(artifactType)}`;
+}
 
 function referrersPrefix(name: string, digest: string): string {
   return `${name}/_referrers/${digest}/`;
@@ -42,7 +130,7 @@ function referrersPath(name: string, subjectDigest: string, digest: string): str
   return `${referrersPrefix(name, subjectDigest)}${digest}`;
 }
 
-function artifactTypeFromManifest(manifest: ManifestSchema): string | undefined {
+export function artifactTypeFromManifest(manifest: ManifestSchema): string | undefined {
   if (manifest.schemaVersion !== 2) {
     return undefined;
   }
@@ -124,6 +212,118 @@ function parseStoredReferrerDescriptor(descriptor: unknown, expectedDigest: stri
   }
 
   return parsedDescriptor;
+}
+
+export function parseCloudchamberSingletonReferrerRecord(
+  record: unknown,
+): CloudchamberSingletonReferrerRecord | null {
+  if (typeof record !== "object" || record === null) {
+    return null;
+  }
+
+  const candidate = record as Record<string, unknown>;
+  if (
+    candidate.version !== cloudchamberSingletonReferrerRecordVersion ||
+    typeof candidate.repository !== "string" ||
+    typeof candidate.subjectDigest !== "string" ||
+    !isValidDigest(candidate.subjectDigest) ||
+    typeof candidate.artifactType !== "string" ||
+    !isCloudchamberSingletonArtifactType(candidate.artifactType) ||
+    typeof candidate.digest !== "string" ||
+    !isValidDigest(candidate.digest) ||
+    typeof candidate.createdAtMs !== "number" ||
+    !Number.isInteger(candidate.createdAtMs) ||
+    candidate.createdAtMs < 0
+  ) {
+    return null;
+  }
+
+  const parsedDescriptor = parseStoredReferrerDescriptor(candidate.descriptor, candidate.digest);
+  if (parsedDescriptor === null || parsedDescriptor.artifactType !== candidate.artifactType) {
+    return null;
+  }
+
+  return {
+    version: cloudchamberSingletonReferrerRecordVersion,
+    repository: candidate.repository,
+    subjectDigest: candidate.subjectDigest,
+    artifactType: candidate.artifactType,
+    digest: candidate.digest,
+    descriptor: parsedDescriptor,
+    createdAtMs: candidate.createdAtMs,
+  };
+}
+
+async function validateSingletonManifestObject(
+  env: Env,
+  name: string,
+  record: CloudchamberSingletonReferrerRecord,
+): Promise<string | null> {
+  const manifestObject = await env.REGISTRY.get(`${name}/manifests/${record.digest}`);
+  if (manifestObject === null) {
+    return `committed manifest ${record.digest} is missing`;
+  }
+
+  let manifestJSON: unknown;
+  try {
+    manifestJSON = await manifestObject.json();
+  } catch {
+    return `committed manifest ${record.digest} is not valid JSON`;
+  }
+
+  const manifestResult = manifestSchema.safeParse(manifestJSON);
+  if (!manifestResult.success) {
+    return `committed manifest ${record.digest} is invalid`;
+  }
+
+  const manifest = manifestResult.data;
+  if (manifest.schemaVersion !== 2 || manifest.subject?.digest !== record.subjectDigest) {
+    return `committed manifest ${record.digest} does not match singleton subject`;
+  }
+
+  const descriptor = descriptorFromManifest(manifest, record.digest, manifestObject.size);
+  if (descriptor === null || descriptor.artifactType !== record.artifactType) {
+    return `committed manifest ${record.digest} does not match singleton artifact type`;
+  }
+
+  return null;
+}
+
+export async function getCloudchamberSingletonReferrerRecord(
+  env: Env,
+  name: string,
+  subjectDigest: string,
+  artifactType: string,
+  options: { validateManifest?: boolean } = {},
+): Promise<CloudchamberSingletonReferrerRecord | RegistryError | null> {
+  const recordObject = await env.REGISTRY.get(singletonReferrerRecordPath(name, subjectDigest, artifactType));
+  if (recordObject === null) {
+    return null;
+  }
+
+  let recordJSON: unknown;
+  try {
+    recordJSON = await recordObject.json();
+  } catch {
+    return singletonArtifactCorruptError(subjectDigest, artifactType, "singleton record is not valid JSON");
+  }
+
+  const record = parseCloudchamberSingletonReferrerRecord(recordJSON);
+  if (record === null) {
+    return singletonArtifactCorruptError(subjectDigest, artifactType, "singleton record has invalid shape");
+  }
+  if (record.repository !== name || record.subjectDigest !== subjectDigest || record.artifactType !== artifactType) {
+    return singletonArtifactCorruptError(subjectDigest, artifactType, "singleton record identity does not match key");
+  }
+
+  if (options.validateManifest === true) {
+    const corruptionReason = await validateSingletonManifestObject(env, name, record);
+    if (corruptionReason !== null) {
+      return singletonArtifactCorruptError(subjectDigest, artifactType, corruptionReason);
+    }
+  }
+
+  return record;
 }
 
 export type Chunk =
@@ -230,6 +430,131 @@ export class R2Registry implements Registry {
 
   constructor(private env: Env) {
     this.gc = new GarbageCollector(this.env.REGISTRY);
+  }
+
+  private async putReferrerDescriptor(
+    name: string,
+    subjectDigest: string,
+    digest: string,
+    descriptor: ReferrerDescriptor,
+  ): Promise<void> {
+    await this.env.REGISTRY.put(referrersPath(name, subjectDigest, digest), JSON.stringify(descriptor), {
+      httpMetadata: {
+        contentType: "application/json",
+      },
+    });
+  }
+
+  private async putSingletonManifest(
+    name: string,
+    subjectDigest: string,
+    digest: string,
+    descriptor: ReferrerDescriptor,
+    text: string,
+    sha256: ArrayBuffer,
+    contentType: string,
+    customMetadata: Record<string, string>,
+  ): Promise<PutManifestResponse | RegistryError> {
+    const existingRecord = await getCloudchamberSingletonReferrerRecord(
+      this.env,
+      name,
+      subjectDigest,
+      cloudchamberBtrfsChainArtifactType,
+      { validateManifest: false },
+    );
+    if (existingRecord !== null && "response" in existingRecord) {
+      return existingRecord;
+    }
+    if (existingRecord !== null) {
+      if (existingRecord.digest !== digest) {
+        const corruptionReason = await validateSingletonManifestObject(this.env, name, existingRecord);
+        if (corruptionReason !== null) {
+          return singletonArtifactCorruptError(
+            subjectDigest,
+            cloudchamberBtrfsChainArtifactType,
+            corruptionReason,
+            409,
+          );
+        }
+        return singletonArtifactExistsError(subjectDigest, cloudchamberBtrfsChainArtifactType, existingRecord.digest);
+      }
+
+      await this.env.REGISTRY.put(`${name}/manifests/${digest}`, text, {
+        sha256,
+        httpMetadata: { contentType },
+        customMetadata,
+      });
+      await this.putReferrerDescriptor(name, subjectDigest, digest, descriptor);
+      return {
+        digest,
+        location: `/v2/${name}/manifests/${digest}`,
+        subject: subjectDigest,
+      };
+    }
+
+    await this.env.REGISTRY.put(`${name}/manifests/${digest}`, text, {
+      sha256,
+      httpMetadata: { contentType },
+      customMetadata,
+    });
+
+    const record: CloudchamberSingletonReferrerRecord = {
+      version: cloudchamberSingletonReferrerRecordVersion,
+      repository: name,
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      digest,
+      descriptor,
+      createdAtMs: Date.now(),
+    };
+    const recordWrite = await this.env.REGISTRY.put(
+      singletonReferrerRecordPath(name, subjectDigest, cloudchamberBtrfsChainArtifactType),
+      JSON.stringify(record),
+      {
+        onlyIf: { etagDoesNotMatch: "*" },
+        httpMetadata: { contentType: "application/json" },
+      },
+    );
+
+    if (recordWrite === null) {
+      const committedRecord = await getCloudchamberSingletonReferrerRecord(
+        this.env,
+        name,
+        subjectDigest,
+        cloudchamberBtrfsChainArtifactType,
+        { validateManifest: false },
+      );
+      if (committedRecord === null) {
+        return singletonArtifactCorruptError(
+          subjectDigest,
+          cloudchamberBtrfsChainArtifactType,
+          "singleton record create lost the race but no committed record exists",
+          409,
+        );
+      }
+      if ("response" in committedRecord) {
+        return committedRecord;
+      }
+      if (committedRecord.digest !== digest) {
+        const corruptionReason = await validateSingletonManifestObject(this.env, name, committedRecord);
+        if (corruptionReason !== null) {
+          return singletonArtifactCorruptError(
+            subjectDigest,
+            cloudchamberBtrfsChainArtifactType,
+            corruptionReason,
+            409,
+          );
+        }
+        return singletonArtifactExistsError(subjectDigest, cloudchamberBtrfsChainArtifactType, committedRecord.digest);
+      }
+    }
+
+    await this.putReferrerDescriptor(name, subjectDigest, digest, descriptor);
+    return {
+      digest,
+      location: `/v2/${name}/manifests/${digest}`,
+      subject: subjectDigest,
+    };
   }
 
   async manifestExists(name: string, reference: string): Promise<RegistryError | CheckManifestResponse> {
@@ -402,14 +727,42 @@ export class R2Registry implements Registry {
     }
 
     const limit = Math.min(Math.max(Math.trunc(options?.limit ?? 100), 1), 1000);
+    const shouldReadSingleton =
+      options?.artifactType === undefined || isCloudchamberSingletonArtifactType(options.artifactType);
+    let singletonDescriptor: ReferrerDescriptor | undefined;
+    if (shouldReadSingleton) {
+      const singletonRecord = await getCloudchamberSingletonReferrerRecord(
+        this.env,
+        name,
+        digest,
+        cloudchamberBtrfsChainArtifactType,
+        { validateManifest: true },
+      );
+      if (singletonRecord !== null && "response" in singletonRecord) {
+        return singletonRecord;
+      }
+      singletonDescriptor = singletonRecord?.descriptor;
+    }
+
+    if (isCloudchamberSingletonArtifactType(options?.artifactType)) {
+      if (singletonDescriptor === undefined || options?.last !== undefined) {
+        return { manifests: [] };
+      }
+      return { manifests: [singletonDescriptor] };
+    }
+
     const prefix = referrersPrefix(name, digest);
-    const manifests: ReferrerDescriptor[] = [];
+    const manifests: ReferrerDescriptor[] =
+      singletonDescriptor !== undefined && options?.last === undefined ? [singletonDescriptor] : [];
     const pageSize = Math.min(Math.max(limit + 1, 100), 1000);
 
     let objects = await this.env.REGISTRY.list({
       prefix,
       limit: pageSize,
-      startAfter: options?.last ? referrersPath(name, digest, options.last) : undefined,
+      startAfter:
+        options?.last !== undefined && options.last !== singletonDescriptor?.digest
+          ? referrersPath(name, digest, options.last)
+          : undefined,
     });
 
     while (true) {
@@ -433,6 +786,10 @@ export class R2Registry implements Registry {
 
         const descriptor = parseStoredReferrerDescriptor(descriptorJSON, expectedDigest);
         if (descriptor === null) {
+          continue;
+        }
+
+        if (isCloudchamberSingletonArtifactType(descriptor.artifactType)) {
           continue;
         }
 
@@ -561,7 +918,34 @@ export class R2Registry implements Registry {
     const customMetadata = {
       hasSubject: subjectDigest !== undefined ? "true" : "false",
       ...(subjectDigest !== undefined ? { subjectDigest } : {}),
+      ...(referrerDescriptor?.artifactType !== undefined ? { artifactType: referrerDescriptor.artifactType } : {}),
     };
+
+    if (
+      referrerDescriptor !== null &&
+      subjectDigest !== undefined &&
+      isCloudchamberSingletonArtifactType(referrerDescriptor.artifactType)
+    ) {
+      if (reference !== digestStr) {
+        return {
+          response: new ManifestError(
+            "TAG_INVALID",
+            `${cloudchamberBtrfsChainArtifactType} artifacts must be published by digest`,
+          ),
+        };
+      }
+
+      return await this.putSingletonManifest(
+        name,
+        subjectDigest,
+        digestStr,
+        referrerDescriptor,
+        text,
+        digest,
+        contentType,
+        customMetadata,
+      );
+    }
 
     const putReference = async () => {
       // if the reference is the same as a digest, it's not necessary to insert
@@ -588,13 +972,7 @@ export class R2Registry implements Registry {
     ];
 
     if (referrerDescriptor !== null && subjectDigest !== undefined) {
-      putTasks.push(
-        env.REGISTRY.put(referrersPath(name, subjectDigest, digestStr), JSON.stringify(referrerDescriptor), {
-          httpMetadata: {
-            contentType: "application/json",
-          },
-        }),
-      );
+      putTasks.push(this.putReferrerDescriptor(name, subjectDigest, digestStr, referrerDescriptor));
     }
 
     await Promise.all(putTasks);

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,7 @@ import { hexToDigest, isValidDigest } from "./user";
 import { ManifestTagsListTooBigError } from "./v2-responses";
 import { Env } from "..";
 import { MINIMUM_CHUNK, MAXIMUM_CHUNK, MAXIMUM_CHUNK_UPLOAD_SIZE } from "./chunk";
+import { manifestSchema } from "./manifest";
 import {
   CheckLayerResponse,
   CheckManifestResponse,
@@ -18,7 +19,13 @@ import {
   registries,
 } from "./registry/registry";
 import { RegistryHTTPClient } from "./registry/http";
-import { ociImageIndexContentType } from "./registry/r2";
+import {
+  artifactTypeFromManifest,
+  cloudchamberBtrfsChainArtifactType,
+  getCloudchamberSingletonReferrerRecord,
+  ociImageIndexContentType,
+  singletonArtifactExistsResponse,
+} from "./registry/r2";
 
 const maxReferrersListLimit = 1000;
 const isOpaqueReferrersCursor = (cursor: string) => cursor.startsWith("/v2/");
@@ -81,14 +88,19 @@ v2Router.delete("/:name+/manifests/:reference", async (req, env: Env) => {
   }
   const manifestDigest = hexToDigest(manifest.checksums.sha256!);
   let subjectDigest = manifest.customMetadata?.subjectDigest;
-  if (subjectDigest === undefined && manifest.customMetadata?.hasSubject !== "false") {
+  let artifactType = manifest.customMetadata?.artifactType;
+  if (manifest.customMetadata?.hasSubject !== "false" || artifactType === undefined) {
     const manifestBody = await env.REGISTRY.get(`${name}/manifests/${reference}`);
     if (manifestBody !== null) {
       try {
-        const manifestJSON = (await manifestBody.json()) as { subject?: { digest: string } };
-        subjectDigest = manifestJSON.subject?.digest;
+        const manifestJSON = await manifestBody.json();
+        const parsedManifest = manifestSchema.safeParse(manifestJSON);
+        if (parsedManifest.success) {
+          subjectDigest = parsedManifest.data.schemaVersion === 2 ? parsedManifest.data.subject?.digest : undefined;
+          artifactType = artifactTypeFromManifest(parsedManifest.data);
+        }
       } catch {
-        subjectDigest = undefined;
+        subjectDigest = manifest.customMetadata?.subjectDigest;
       }
     }
   }
@@ -96,6 +108,23 @@ v2Router.delete("/:name+/manifests/:reference", async (req, env: Env) => {
   if (!Number.isInteger(limitInt) || limitInt <= 0 || limitInt > 1000) {
     throw new ServerError("invalid 'limit' parameter", 400);
   }
+
+  if (reference === manifestDigest && subjectDigest !== undefined && artifactType === cloudchamberBtrfsChainArtifactType) {
+    const singletonRecord = await getCloudchamberSingletonReferrerRecord(
+      env,
+      name,
+      subjectDigest,
+      cloudchamberBtrfsChainArtifactType,
+      { validateManifest: false },
+    );
+    if (singletonRecord !== null && "response" in singletonRecord) {
+      return singletonRecord.response;
+    }
+    if (singletonRecord?.digest === manifestDigest) {
+      return singletonArtifactExistsResponse(subjectDigest, cloudchamberBtrfsChainArtifactType, manifestDigest);
+    }
+  }
+
   const tags = await env.REGISTRY.list({
     prefix: `${name}/manifests`,
     limit: limitInt,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,6 +7,7 @@ import { RegistryAuthProtocolTokenPayload } from "../src/auth";
 import { registries } from "../src/registry/registry";
 import type { ReferrerDescriptor } from "../src/registry/registry";
 import { isDockerDotIO, RegistryHTTPClient } from "../src/registry/http";
+import { cloudchamberBtrfsChainArtifactType, singletonReferrerRecordPath } from "../src/registry/r2";
 import { encode } from "@cfworker/base64url";
 import { ManifestSchema } from "../src/manifest";
 import { limit } from "../src/chunk";
@@ -212,22 +213,27 @@ function manifestSize(schema: ManifestSchema): number {
   return new Blob([JSON.stringify(schema)]).size;
 }
 
+async function putManifestRequest(
+  name: string,
+  schema: ManifestSchema,
+  reference?: string,
+): Promise<{ sha256: string; response: Response }> {
+  const data = JSON.stringify(schema);
+  const sha256 = await getSHA256(data);
+  const response = await fetch(
+    createRequest("PUT", `/v2/${name}/manifests/${reference ?? sha256}`, new Blob([data]).stream(), {
+      "Content-Type": "application/gzip",
+    }),
+  );
+  return { sha256, response };
+}
+
 async function uploadManifest(
   name: string,
   schema: ManifestSchema,
   tag?: string,
 ): Promise<{ sha256: string; response: Response }> {
-  const data = JSON.stringify(schema);
-  const sha256 = await getSHA256(data);
-  if (!tag) {
-    tag = sha256;
-  }
-
-  const response = await fetch(
-    createRequest("PUT", `/v2/${name}/manifests/${tag}`, new Blob([data]).stream(), {
-      "Content-Type": "application/gzip",
-    }),
-  );
+  const { sha256, response } = await putManifestRequest(name, schema, tag);
   if (!response.ok) {
     throw new Error(await response.text());
   }
@@ -486,7 +492,7 @@ describe("v2 referrers", () => {
       digest: subjectDigest,
       size: manifestSize(subjectManifest),
     };
-    const artifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const artifactType = "application/vnd.cloudchamber.test-referrer.v1";
     const artifactManifestOne = {
       ...getImageManifestV2(await generateManifest(name)),
       artifactType,
@@ -538,6 +544,279 @@ describe("v2 referrers", () => {
     expect(returnedDigests).toEqual(new Set([firstArtifactDigest, secondArtifactDigest]));
   });
 
+  test("Cloudchamber btrfs-chain artifacts are singleton referrers", async () => {
+    const name = "referrers-cloudchamber-singleton";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const subjectDescriptor = {
+      mediaType: subjectManifest.mediaType,
+      digest: subjectDigest,
+      size: manifestSize(subjectManifest),
+    };
+    const firstArtifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      annotations: {
+        "org.opencontainers.image.title": "chain-one",
+      },
+      subject: subjectDescriptor,
+    } satisfies ManifestSchema;
+    const secondArtifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      annotations: {
+        "org.opencontainers.image.title": "chain-two",
+      },
+      subject: subjectDescriptor,
+    } satisfies ManifestSchema;
+
+    const { sha256: firstArtifactDigest, response: firstArtifactResponse } = await putManifestRequest(
+      name,
+      firstArtifactManifest,
+    );
+    expect(firstArtifactResponse.status).toEqual(201);
+    expect(firstArtifactResponse.headers.get("oci-subject")).toEqual(subjectDigest);
+
+    const singletonRecord = await bindings.REGISTRY.get(
+      singletonReferrerRecordPath(name, subjectDigest, cloudchamberBtrfsChainArtifactType),
+    );
+    expect(singletonRecord).not.toBeNull();
+    expect(await singletonRecord?.json()).toMatchObject({
+      version: 1,
+      repository: name,
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      digest: firstArtifactDigest,
+      descriptor: {
+        mediaType: firstArtifactManifest.mediaType,
+        digest: firstArtifactDigest,
+        size: manifestSize(firstArtifactManifest),
+        artifactType: cloudchamberBtrfsChainArtifactType,
+        annotations: firstArtifactManifest.annotations,
+      },
+    });
+
+    const { response: secondArtifactResponse } = await putManifestRequest(name, secondArtifactManifest);
+    expect(secondArtifactResponse.status).toEqual(409);
+    expect(await secondArtifactResponse.json()).toEqual({
+      code: "SINGLETON_ARTIFACT_EXISTS",
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      committedDigest: firstArtifactDigest,
+    });
+
+    const idempotentResponse = await putManifestRequest(name, firstArtifactManifest, firstArtifactDigest);
+    expect(idempotentResponse.response.status).toEqual(201);
+    expect(idempotentResponse.response.headers.get("docker-content-digest")).toEqual(firstArtifactDigest);
+
+    await seedReferrerIndex(name, subjectDigest, [
+      {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: numberedDigest(7777),
+        size: 1,
+        artifactType: cloudchamberBtrfsChainArtifactType,
+      },
+    ]);
+
+    const expectedDescriptor = {
+      mediaType: firstArtifactManifest.mediaType,
+      digest: firstArtifactDigest,
+      size: manifestSize(firstArtifactManifest),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      annotations: firstArtifactManifest.annotations,
+    };
+    const filteredReferrers = await getReferrersIndex(
+      name,
+      subjectDigest,
+      new URLSearchParams({ artifactType: cloudchamberBtrfsChainArtifactType }),
+    );
+    expect(filteredReferrers.body.manifests).toEqual([expectedDescriptor]);
+
+    const unfilteredReferrers = await getReferrersIndex(name, subjectDigest);
+    expect(
+      unfilteredReferrers.body.manifests.filter(
+        (manifest) => manifest.artifactType === cloudchamberBtrfsChainArtifactType,
+      ),
+    ).toEqual([expectedDescriptor]);
+  });
+
+  test("Cloudchamber btrfs-chain artifacts reject mutable tags", async () => {
+    const name = "referrers-cloudchamber-singleton-tag";
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+
+    const { response } = await putManifestRequest(name, artifactManifest, "mutable-tag");
+    expect(response.status).toEqual(400);
+    expect((await response.json()) as { errors: { code: string }[] }).toEqual({
+      errors: [expect.objectContaining({ code: "TAG_INVALID" })],
+    });
+  });
+
+  test("Cloudchamber btrfs-chain singleton deletion is rejected", async () => {
+    const name = "referrers-cloudchamber-singleton-delete";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+    const replacementManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      subject: artifactManifest.subject,
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await uploadManifest(name, artifactManifest);
+    const deleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/${artifactDigest}`, null));
+    expect(deleteResponse.status).toEqual(409);
+    expect(await deleteResponse.json()).toEqual({
+      code: "SINGLETON_ARTIFACT_EXISTS",
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      committedDigest: artifactDigest,
+    });
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeTruthy();
+
+    const { response: replacementResponse } = await putManifestRequest(name, replacementManifest);
+    expect(replacementResponse.status).toEqual(409);
+    expect(await replacementResponse.json()).toEqual({
+      code: "SINGLETON_ARTIFACT_EXISTS",
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      committedDigest: artifactDigest,
+    });
+  });
+
+  test("Cloudchamber btrfs-chain singleton corruption is reported", async () => {
+    const name = "referrers-cloudchamber-singleton-corrupt";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const artifactManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+    } satisfies ManifestSchema;
+    const replacementManifest = {
+      ...getImageManifestV2(await generateManifest(name)),
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      subject: artifactManifest.subject,
+    } satisfies ManifestSchema;
+
+    const { sha256: artifactDigest } = await uploadManifest(name, artifactManifest);
+    await bindings.REGISTRY.delete(`${name}/manifests/${artifactDigest}`);
+
+    const referrersResponse = await fetch(
+      createRequest(
+        "GET",
+        `/v2/${name}/referrers/${subjectDigest}?artifactType=${encodeURIComponent(cloudchamberBtrfsChainArtifactType)}`,
+        null,
+      ),
+    );
+    expect(referrersResponse.status).toEqual(500);
+    expect(await referrersResponse.json()).toEqual({
+      code: "SINGLETON_ARTIFACT_CORRUPT",
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      reason: `committed manifest ${artifactDigest} is missing`,
+    });
+
+    const { response: replacementResponse } = await putManifestRequest(name, replacementManifest);
+    expect(replacementResponse.status).toEqual(409);
+    expect(await replacementResponse.json()).toEqual({
+      code: "SINGLETON_ARTIFACT_CORRUPT",
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      reason: `committed manifest ${artifactDigest} is missing`,
+    });
+  });
+
+  test("Cloudchamber btrfs-chain malformed singleton records are reported", async () => {
+    const name = "referrers-cloudchamber-singleton-malformed";
+    const bindings = env as Env;
+    const subjectDigest = numberedDigest(7788);
+    await bindings.REGISTRY.put(singletonReferrerRecordPath(name, subjectDigest, cloudchamberBtrfsChainArtifactType), "{", {
+      httpMetadata: { contentType: "application/json" },
+    });
+
+    const response = await fetch(
+      createRequest(
+        "GET",
+        `/v2/${name}/referrers/${subjectDigest}?artifactType=${encodeURIComponent(cloudchamberBtrfsChainArtifactType)}`,
+        null,
+      ),
+    );
+    expect(response.status).toEqual(500);
+    expect(await response.json()).toEqual({
+      code: "SINGLETON_ARTIFACT_CORRUPT",
+      subjectDigest,
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      reason: "singleton record is not valid JSON",
+    });
+  });
+
+  test("GC keeps committed Cloudchamber btrfs-chain singleton artifacts", async () => {
+    const name = "referrers-cloudchamber-singleton-gc";
+    const bindings = env as Env;
+    const subjectManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
+    const childManifest = getImageManifestV2(await generateManifest(name));
+    const { sha256: childDigest } = await createManifest(name, childManifest);
+    const artifactIndex = {
+      schemaVersion: 2,
+      mediaType: "application/vnd.oci.image.index.v1+json",
+      artifactType: cloudchamberBtrfsChainArtifactType,
+      subject: {
+        mediaType: subjectManifest.mediaType,
+        digest: subjectDigest,
+        size: manifestSize(subjectManifest),
+      },
+      manifests: [
+        {
+          mediaType: childManifest.mediaType,
+          digest: childDigest,
+          size: manifestSize(childManifest),
+        },
+      ],
+    } satisfies ManifestSchema;
+    const { sha256: artifactDigest } = await uploadManifest(name, artifactIndex);
+
+    const subjectTagDeleteResponse = await fetch(createRequest("DELETE", `/v2/${name}/manifests/latest`, null));
+    expect(subjectTagDeleteResponse.status).toEqual(202);
+
+    await runGarbageCollector(name, "untagged");
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${subjectDigest}`)).toBeNull();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${artifactDigest}`)).toBeTruthy();
+    expect(await bindings.REGISTRY.head(`${name}/manifests/${childDigest}`)).toBeTruthy();
+
+    const referrers = await getReferrersIndex(
+      name,
+      subjectDigest,
+      new URLSearchParams({ artifactType: cloudchamberBtrfsChainArtifactType }),
+    );
+    expect(referrers.body.manifests.map((manifest) => manifest.digest)).toEqual([artifactDigest]);
+  });
+
   test("GET /v2/:name/referrers/:digest filters descriptors and returns empty results", async () => {
     const name = "referrers-filter";
     const subjectManifest = getImageManifestV2(await generateManifest(name));
@@ -548,7 +827,7 @@ describe("v2 referrers", () => {
       size: manifestSize(subjectManifest),
     };
 
-    const explicitArtifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const explicitArtifactType = "application/vnd.cloudchamber.test-referrer.v1";
     const derivedArtifactType = "application/vnd.cloudchamber.chain.config.v1+json";
     const explicitArtifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
@@ -644,7 +923,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -700,7 +979,7 @@ describe("v2 referrers", () => {
     const childManifest = getImageManifestV2(await generateManifest(name));
     const { sha256: childDigest } = await createManifest(name, childManifest, "child");
 
-    const artifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const artifactType = "application/vnd.cloudchamber.test-referrer.v1";
     const artifactIndex = {
       schemaVersion: 2,
       mediaType: "application/vnd.oci.image.index.v1+json",
@@ -762,7 +1041,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -792,7 +1071,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -839,7 +1118,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -859,7 +1138,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const firstArtifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       annotations: {
         "org.opencontainers.image.title": "chain-one",
       },
@@ -871,7 +1150,7 @@ describe("v2 referrers", () => {
     } satisfies ManifestSchema;
     const secondArtifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       annotations: {
         "org.opencontainers.image.title": "chain-two",
       },
@@ -905,7 +1184,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -932,7 +1211,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -974,7 +1253,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       annotations: {
         "org.opencontainers.image.title": "tagged-referrer",
       },
@@ -1018,7 +1297,7 @@ describe("v2 referrers", () => {
     const artifactIndex = {
       schemaVersion: 2,
       mediaType: "application/vnd.oci.image.index.v1+json",
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -1055,7 +1334,7 @@ describe("v2 referrers", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -1081,7 +1360,7 @@ describe("v2 referrers", () => {
     const name = "referrers-invalid-subject";
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: "application/vnd.oci.image.manifest.v1+json",
         digest: "sha256/not-a-digest",
@@ -1134,7 +1413,7 @@ describe("v2 referrers", () => {
     const invalidIndex = {
       schemaVersion: 2,
       mediaType: "application/vnd.oci.image.index.v1+json",
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,
@@ -1451,7 +1730,7 @@ describe("http client", () => {
   test("test list referrers", async () => {
     const name = "http-client-referrers";
     const subjectDigest = numberedDigest(9997);
-    const artifactType = "application/vnd.cloudchamber.btrfs-chain.v1";
+    const artifactType = "application/vnd.cloudchamber.test-referrer.v1";
     const firstArtifactDigest = numberedDigest(9998);
     const secondArtifactDigest = numberedDigest(9999);
     const firstDescriptor = {
@@ -1950,7 +2229,7 @@ describe("push and catalog", () => {
     const { sha256: subjectDigest } = await createManifest(name, subjectManifest, "latest");
     const artifactManifest = {
       ...getImageManifestV2(await generateManifest(name)),
-      artifactType: "application/vnd.cloudchamber.btrfs-chain.v1",
+      artifactType: "application/vnd.cloudchamber.test-referrer.v1",
       subject: {
         mediaType: subjectManifest.mediaType,
         digest: subjectDigest,


### PR DESCRIPTION
Snapshot-enabled deployments need the registry-published btrfs-chain base to be the sole portable rootfs base for an image digest.

Make the R2 registry commit that artifact through a conditional singleton record, synthesize referrers from it, and reject deletion or corrupt replacement so stale builders cannot publish competing bases.