### PR TITLE
ci(test): scope GITHUB_TOKEN to contents: read

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Unit Tests


### PR DESCRIPTION
Drops the default `GITHUB_TOKEN` scope down to `contents: read` for `test.yml`. It only runs `pnpm typecheck` and `pnpm test` in a Node matrix, with no calls to the GitHub API beyond the standard checkout.

The other workflow here (`semgrep.yml`) already declares its permissions. YAML validated locally.