### PR TITLE
fix(r2): report source digest/size for mounted-blob HEAD (builds on #121)

### DIFF
--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -198,6 +198,8 @@ export async function encodeState(state: State, env: Env): Promise<{ jwt: string
 }
 
 export const symlinkHeader = "X-Serverless-Registry-Symlink";
+export const symlinkDigestHeader = "X-Serverless-Registry-Symlink-Digest";
+export const symlinkSizeHeader = "X-Serverless-Registry-Symlink-Size";
 
 export async function getUploadState(
   name: string,
@@ -650,11 +652,22 @@ export class R2Registry implements Registry {
       // Trying to mount a layer from sourceLayerPath to destinationLayerPath
 
       // Create linked file with custom metadata
+      if (res.checksums.sha256 === null) {
+        return { response: new ServerError("invalid checksum from R2 backend") };
+      }
       const [newFile, error] = await wrap(
         this.env.REGISTRY.put(destinationLayerPath, sourceLayerPath, {
+          // Symlink object content is the source blob path string.
+          // The object checksum must match the symlink payload to satisfy R2.
           sha256: await getSHA256(sourceLayerPath, ""),
           httpMetadata: res.httpMetadata,
-          customMetadata: { [symlinkHeader]: sourceName }, // Storing target repository name in metadata (to easily resolve recursive layer mounting)
+          customMetadata: {
+            // Storing target repository name in metadata (to easily resolve recursive layer mounting)
+            [symlinkHeader]: sourceName,
+            // Store source layer metadata so HEAD can answer without loading symlink body.
+            [symlinkDigestHeader]: digest,
+            [symlinkSizeHeader]: `${res.size}`,
+          },
         }),
       );
       if (error) {
@@ -681,6 +694,63 @@ export class R2Registry implements Registry {
       return {
         exists: false,
       };
+    }
+
+    const expectedDigest =
+      tag.startsWith("sha256:") && tag.length > SHA256_PREFIX_LEN ? tag.slice(SHA256_PREFIX_LEN) : null;
+    const symlinkByChecksumMismatch =
+      expectedDigest !== null && res.checksums.sha256 !== null && res.checksums.sha256 !== expectedDigest;
+    const symlinkMetadata = res.customMetadata ?? {};
+    const symlinkByMetadata = symlinkHeader in symlinkMetadata;
+
+    // Handle R2 symlink layers.
+    // We detect symlinks by:
+    // 1) explicit metadata, or
+    // 2) checksum mismatch between requested digest and R2 object checksum
+    //    (the symlink object checksum is based on symlink payload, not mounted blob bytes).
+    if (symlinkByMetadata || symlinkByChecksumMismatch) {
+      // Fast path for symlinks created by newer versions that include source metadata.
+      const metadataSize = +(symlinkMetadata[symlinkSizeHeader] ?? "");
+      const metadataDigest = symlinkMetadata[symlinkDigestHeader];
+      if (Number.isFinite(metadataSize) && metadataSize >= 0 && metadataDigest) {
+        return {
+          digest: metadataDigest,
+          size: metadataSize,
+          exists: true,
+        };
+      }
+
+      // Backward-compatibility path for old symlinks: resolve link body and query target.
+      const [obj, getErr] = await wrap(this.env.REGISTRY.get(`${name}/blobs/${tag}`));
+      if (getErr) {
+        return wrapError("layerExists", getErr);
+      }
+      if (!obj) {
+        return { exists: false };
+      }
+
+      const layerPath = await obj.text();
+      const [linkName, linkDigest] = layerPath.split("/blobs/");
+      if (!linkName || !linkDigest) {
+        // Backward compatibility: if this does not look like a symlink payload,
+        // fall back to object metadata from HEAD.
+        if (res.checksums.sha256 === null) {
+          return { response: new ServerError("invalid checksum from R2 backend") };
+        }
+
+        return {
+          digest: hexToDigest(res.checksums.sha256!),
+          size: res.size,
+          exists: true,
+        };
+      }
+
+      // Prevent recursive self-reference.
+      if (linkName === name && linkDigest === tag) {
+        return { exists: false };
+      }
+
+      return await this.env.REGISTRY_CLIENT.layerExists(linkName, linkDigest);
     }
 
     return {

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -696,10 +696,10 @@ export class R2Registry implements Registry {
       };
     }
 
-    const expectedDigest =
-      tag.startsWith("sha256:") && tag.length > SHA256_PREFIX_LEN ? tag.slice(SHA256_PREFIX_LEN) : null;
+    const expectedDigest = tag.startsWith("sha256:") ? tag : null;
+    const actualDigest = res.checksums.sha256 ? hexToDigest(res.checksums.sha256) : null;
     const symlinkByChecksumMismatch =
-      expectedDigest !== null && res.checksums.sha256 !== null && res.checksums.sha256 !== expectedDigest;
+      expectedDigest !== null && actualDigest !== null && actualDigest !== expectedDigest;
     const symlinkMetadata = res.customMetadata ?? {};
     const symlinkByMetadata = symlinkHeader in symlinkMetadata;
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -590,9 +590,12 @@ v2Router.put("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
 v2Router.head("/:name+/blobs/:tag", async (req, env: Env) => {
   const { name, tag } = req.params;
 
-  const res = await env.REGISTRY.head(`${name}/blobs/${tag}`);
   let layerExistsResponse: CheckLayerResponse | null = null;
-  if (!res) {
+  const localResponse = await env.REGISTRY_CLIENT.layerExists(name, tag);
+  if ("response" in localResponse) {
+    return localResponse.response;
+  }
+  if (!localResponse.exists) {
     const registryList = registries(env);
     for (const registry of registryList) {
       const client = new RegistryHTTPClient(env, registry);
@@ -610,15 +613,7 @@ v2Router.head("/:name+/blobs/:tag", async (req, env: Env) => {
     if (layerExistsResponse === null || !layerExistsResponse.exists)
       return new Response(JSON.stringify(BlobUnknownError), { status: 404 });
   } else {
-    if (res.checksums.sha256 === null) {
-      throw new ServerError("invalid checksum from R2 backend");
-    }
-
-    layerExistsResponse = {
-      digest: hexToDigest(res.checksums.sha256!),
-      size: res.size,
-      exists: true,
-    };
+    layerExistsResponse = localResponse;
   }
 
   return new Response(null, {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -474,6 +474,17 @@ describe("v2 manifests", () => {
         expect(layerC.ok).toBeTruthy();
         expect(await layerB.bytes()).toEqual(sourceData);
         expect(await layerC.bytes()).toEqual(sourceData);
+
+        // Check layer HEAD returns source metadata for mounted symlinks.
+        const layerHeadB = await fetch(createRequest("HEAD", `/v2/${repoB}/blobs/${layer}`, null));
+        expect(layerHeadB.ok).toBeTruthy();
+        expect(layerHeadB.headers.get("Docker-Content-Digest")).toEqual(layer);
+        expect(+(layerHeadB.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
+
+        const layerHeadC = await fetch(createRequest("HEAD", `/v2/${repoC}/blobs/${layer}`, null));
+        expect(layerHeadC.ok).toBeTruthy();
+        expect(layerHeadC.headers.get("Docker-Content-Digest")).toEqual(layer);
+        expect(+(layerHeadC.headers.get("Content-Length") ?? "-1")).toEqual(sourceData.byteLength);
       }
     }
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2391,3 +2391,31 @@ test("docker.io", () => {
     }
   }
 });
+
+describe("mounted blob HEAD reports source metadata", () => {
+  test("HEAD of a cross-repo mounted blob returns the source digest and size, not the symlink's", async () => {
+    const src = "mountsrc/repo";
+    const dst = "mountdst/repo";
+    const data = "cross-repo-mounted-layer-bytes";
+    const digest = await getSHA256(data);
+
+    // Push the blob into the source repo.
+    const post = await fetch(createRequest("POST", `/v2/${src}/blobs/uploads/`, null, {}));
+    const patch = await fetch(
+      createRequest("PATCH", post.headers.get("location")!, limit(new Blob([data]).stream(), data.length), {}),
+    );
+    const put = await fetch(createRequest("PUT", patch.headers.get("location")! + "&digest=" + digest, null, {}));
+    expect(put.ok).toBeTruthy();
+
+    // Cross-repo mount into the destination repo (stored as a symlink object).
+    const mount = await fetch(createRequest("POST", `/v2/${dst}/blobs/uploads/?from=${src}&mount=${digest}`, null, {}));
+    expect(mount.status).toBe(201);
+    expect(mount.headers.get("docker-content-digest")).toEqual(digest);
+
+    // HEAD the mounted blob: must report the source blob's size + digest, not the symlink object's.
+    const head = await fetch(createRequest("HEAD", `/v2/${dst}/blobs/${digest}`, null));
+    expect(head.status).toBe(200);
+    expect(head.headers.get("Content-Length")).toEqual(`${data.length}`);
+    expect(head.headers.get("Docker-Content-Digest")).toEqual(digest);
+  });
+});


### PR DESCRIPTION
### Problem
A HEAD on a mounted (cross-repo) blob returns the symlink object's own digest/size instead of the source blob's. #121 set out to fix this; this PR builds on that approach and corrects a defect in it: the symlink checksum-mismatch test compares the raw R2 checksum (`ArrayBuffer`) to a hex string, which does not type-check and, at runtime, is always true — so every digest-addressed blob would be routed through symlink resolution.

### Solution
Credit and carry #121's approach (record the source digest/size on the symlink object's metadata; resolve HEAD through `layerExists`, with a fallback for symlinks created before the fix), then fix the comparison to put full `sha256:…` digest strings on both sides (via `hexToDigest`), so a normal blob compares equal (no mismatch) and only a real symlink object mismatches.

### Tests
Adds regression coverage for cross-repo mounted-blob HEAD returning the source digest/size.

Builds on #121 by @mushanyoung.
