### PR TITLE
refactor: build manifestTypes from named media-type constants (de-duplicate literals)

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
-
-const dockerManifestListContentType = "application/vnd.docker.distribution.manifest.list.v2+json";
+import { dockerManifestListContentType } from "./media-types";
 
 const platformSchema = z.object({
   "architecture": z.string(),

--- a/src/media-types.ts
+++ b/src/media-types.ts
@@ -1,0 +1,10 @@
+// Named constants for the manifest media types the registry recognizes during content
+// negotiation. These strings are the OCI/Docker content-negotiation contract and must stay
+// byte-identical to the specification, so each is defined exactly once here and referenced
+// everywhere else. This module has no imports, keeping it a safe leaf to import from anywhere.
+
+export const dockerManifestListContentType = "application/vnd.docker.distribution.manifest.list.v2+json";
+export const ociImageIndexContentType = "application/vnd.oci.image.index.v1+json";
+export const dockerManifestV1PrettyJwsContentType = "application/vnd.docker.distribution.manifest.v1+prettyjws";
+export const ociImageManifestContentType = "application/vnd.oci.image.manifest.v1+json";
+export const dockerManifestV2ContentType = "application/vnd.docker.distribution.manifest.v2+json";

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -18,7 +18,13 @@ import {
   UploadId,
   UploadObject,
 } from "./registry";
-import { ociImageIndexContentType } from "./r2";
+import {
+  dockerManifestListContentType,
+  ociImageIndexContentType,
+  dockerManifestV1PrettyJwsContentType,
+  ociImageManifestContentType,
+  dockerManifestV2ContentType,
+} from "../media-types";
 
 type AuthContext = {
   authType: AuthType;
@@ -45,12 +51,12 @@ type HTTPContext = {
 };
 
 export const manifestTypes = [
-  "application/vnd.docker.distribution.manifest.list.v2+json",
-  "application/vnd.oci.image.index.v1+json",
-  "application/vnd.docker.distribution.manifest.v1+prettyjws",
+  dockerManifestListContentType,
+  ociImageIndexContentType,
+  dockerManifestV1PrettyJwsContentType,
   "application/json",
-  "application/vnd.oci.image.manifest.v1+json",
-  "application/vnd.docker.distribution.manifest.v2+json",
+  ociImageManifestContentType,
+  dockerManifestV2ContentType,
 ] as const;
 
 export type ManifestType = (typeof manifestTypes)[number];

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -32,8 +32,6 @@ import {
 import { GarbageCollectionMode, GarbageCollector } from "./garbage-collector";
 import { ManifestSchema, manifestSchema } from "../manifest";
 
-export const ociImageIndexContentType = "application/vnd.oci.image.index.v1+json";
-
 function referrersPrefix(name: string, digest: string): string {
   return `${name}/_referrers/${digest}/`;
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -18,7 +18,7 @@ import {
   registries,
 } from "./registry/registry";
 import { RegistryHTTPClient } from "./registry/http";
-import { ociImageIndexContentType } from "./registry/r2";
+import { ociImageIndexContentType } from "./media-types";
 
 const maxReferrersListLimit = 1000;
 const isOpaqueReferrersCursor = (cursor: string) => cursor.startsWith("/v2/");

--- a/test/media-types.test.ts
+++ b/test/media-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import { manifestTypes } from "../src/registry/http";
+import {
+  dockerManifestListContentType,
+  ociImageIndexContentType,
+  dockerManifestV1PrettyJwsContentType,
+  ociImageManifestContentType,
+  dockerManifestV2ContentType,
+} from "../src/media-types";
+
+describe("manifest media types", () => {
+  // The Accept header is emitted as manifestTypes.join(", "), so both the exact string values
+  // and the array order are part of the content-negotiation wire contract. This pins them so a
+  // value edit or a reorder fails here rather than silently changing what the registry sends.
+  test("manifestTypes holds the expected set in the expected order", () => {
+    expect(manifestTypes).toEqual([
+      "application/vnd.docker.distribution.manifest.list.v2+json",
+      "application/vnd.oci.image.index.v1+json",
+      "application/vnd.docker.distribution.manifest.v1+prettyjws",
+      "application/json",
+      "application/vnd.oci.image.manifest.v1+json",
+      "application/vnd.docker.distribution.manifest.v2+json",
+    ]);
+  });
+
+  test("each manifest media-type constant holds its spec string", () => {
+    expect(dockerManifestListContentType).toBe("application/vnd.docker.distribution.manifest.list.v2+json");
+    expect(ociImageIndexContentType).toBe("application/vnd.oci.image.index.v1+json");
+    expect(dockerManifestV1PrettyJwsContentType).toBe("application/vnd.docker.distribution.manifest.v1+prettyjws");
+    expect(ociImageManifestContentType).toBe("application/vnd.oci.image.manifest.v1+json");
+    expect(dockerManifestV2ContentType).toBe("application/vnd.docker.distribution.manifest.v2+json");
+  });
+});


### PR DESCRIPTION
### Problem
The manifest content-negotiation accept-list `manifestTypes` (`src/registry/http.ts`) is built from bare string literals, but named constants for two of those exact media types already exist and are bypassed:

- `application/vnd.docker.distribution.manifest.list.v2+json` — already held by `dockerManifestListContentType` in `src/manifest.ts` (and used there to validate a manifest's `mediaType`).
- `application/vnd.oci.image.index.v1+json` — already held by `ociImageIndexContentType` in `src/registry/r2.ts`, which is even imported into `http.ts` and used for index handling — yet the accept-list re-types the literal instead of using it.
- `application/vnd.oci.image.manifest.v1+json` has no named constant at all.

These strings are the OCI/Docker content-negotiation contract and must stay byte-identical to the spec. With the same value living in two places, editing one (say, as the spec evolves) silently diverges from the other: the index-handling path would use the updated constant while the accept-list kept the stale literal, so a client sending that type would be rejected at negotiation even though the handler was ready for it — a failure a happy-path test using one consistent string would not catch.

### Solution
Add a single `src/media-types.ts` (a zero-import leaf module) that defines every manifest media-type constant exactly once, and build `manifestTypes` from those constants. The existing consumers — `src/manifest.ts`, `src/registry/r2.ts`, `src/registry/http.ts`, `src/router.ts` — all import from that one source.

Pure, behavior-preserving refactor: the string values and the array order are unchanged (order matters — `Accept` is emitted as `manifestTypes.join(", ")`), `as const` is kept so the `ManifestType` union resolves to the identical set, and no runtime behavior changes.

### Tests
Adds `test/media-types.test.ts` asserting `manifestTypes` holds the expected set in the expected order, plus each constant's value.

Part of #134.
