### PR TITLE
Add structured logging and Analytics Engine metrics (DEVPROD-4153)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ import v2Router from "./src/router";
 import { authenticationMethodFromEnv } from "./src/authentication-method";
 import { Registry } from "./src/registry/registry";
 import { R2Registry } from "./src/registry/r2";
+import { log } from "./src/log";
 
 // A full compatibility mode means that the r2 registry will try its best to
 // help the client on the layer push. See how we let the client push layers with chunked uploads for more information.
@@ -15,6 +16,7 @@ type PushCompatibilityMode = "full" | "none";
 
 export interface Env {
   REGISTRY: R2Bucket;
+  METRICS?: AnalyticsEngineDataset;
   ENVIRONMENT: string;
   JWT_REGISTRY_TOKENS_PUBLIC_KEY?: string;
   USERNAME?: string;
@@ -35,20 +37,37 @@ router.all("/v2/*", v2Router.fetch);
 
 router.all("*", () => new Response("Not Found.", { status: 404 }));
 
+function recordMetric(env: Env, outcome: string, status: number, durationMs: number): void {
+  // blobs[0] is a fixed "registry" source tag: the METRICS dataset is shared
+  // with the auth Worker (a separate deployable, instrumented in the
+  // companion devprod-infra plan), so the alerting Worker's queries group by
+  // this dimension to compute per-source error rates.
+  env.METRICS?.writeDataPoint({
+    blobs: ["registry", outcome],
+    doubles: [durationMs],
+    indexes: [String(status)],
+  });
+}
+
 export default {
   async fetch(request: Request, env: Env, context?: ExecutionContext) {
+    const start = Date.now();
+
     if (!ensureConfig(env)) {
+      recordMetric(env, "config_error", 500, Date.now() - start);
       return new AuthErrorResponse(request);
     }
 
     const authMethod = await authenticationMethodFromEnv(env);
     if (!authMethod) {
+      recordMetric(env, "config_error", 500, Date.now() - start);
       return new AuthErrorResponse(request);
     }
 
     const credentials = await authMethod.checkCredentials(request);
     if (!credentials.verified) {
-      console.warn(`Not Authorized. authmode=${authMethod.authmode}. verified=false`);
+      log.warn("auth_denied", { authmode: authMethod.authmode });
+      recordMetric(env, "auth_denied", 401, Date.now() - start);
       return new AuthErrorResponse(request);
     }
 
@@ -56,26 +75,29 @@ export default {
     try {
       // Dispatch the request to the appropriate route
       const res = await router.fetch(request, env, context);
+      recordMetric(env, "success", res.status, Date.now() - start);
       return res;
     } catch (err) {
       if (err instanceof Response) {
-        console.warn(`${request.method} ${err.status} ${err.url}`);
+        log.warn("router_error_response", { method: request.method, status: err.status, url: err.url });
+        recordMetric(env, "router_error", err.status, Date.now() - start);
         return err;
       }
 
       // Unexpected error
       if (err instanceof Error) {
-        console.error(
-          "An error has been thrown by the router:\n",
-          `${err.name}: ${err.message}: ${err.cause}: ${err.stack}`,
-        );
+        log.error("unhandled_error", {
+          name: err.name,
+          message: err.message,
+          cause: err.cause ? String(err.cause) : null,
+          stack: err.stack ?? null,
+        });
+        recordMetric(env, "unhandled_error", 500, Date.now() - start);
         return new InternalError();
       }
 
-      console.error(
-        "An error has been thrown and is neither a Response or an Error, JSON.stringify() =",
-        JSON.stringify(err),
-      );
+      log.error("unhandled_non_error", { value: JSON.stringify(err) });
+      recordMetric(env, "unhandled_error", 500, Date.now() - start);
       return new InternalError();
     }
   },
@@ -83,9 +105,9 @@ export default {
 
 const ensureConfig = (env: Env): boolean => {
   if (!env.REGISTRY) {
-    console.error(
-      "env.REGISTRY is not setup. Please setup an R2 bucket and add the binding in wrangler.toml. Try 'npx wrangler --env production r2 bucket create r2-registry'",
-    );
+    log.error("missing_registry_binding", {
+      hint: "Setup an R2 bucket and add the binding in wrangler.toml. Try 'npx wrangler --env production r2 bucket create r2-registry'",
+    });
     return false;
   }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,6 @@
 import { decode } from "@cfworker/base64url";
 import { errorString } from "./utils";
+import { log } from "./log";
 
 export type RegistryTokenCapability = "push" | "pull";
 export type RegistryAuthProtocolTokenPayload = {
@@ -36,7 +37,7 @@ export function stripUsernamePasswordFromHeader(r: Request): [string, string] | 
 
   // we strictly assume that auth scheme can only be Basic
   if (!encoded || scheme !== "Basic") {
-    console.warn("failed checkCredentials: Authorization doesn't include Basic scheme");
+    log.warn("basic_auth_scheme_invalid", {});
     return { verified: false, payload: null };
   }
 
@@ -59,7 +60,7 @@ export function stripUsernamePasswordFromHeader(r: Request): [string, string] | 
     const password = decoded.substring(index + 1);
     return [username, password];
   } catch (err) {
-    console.error(`Failure getting data from Authorization header: ${errorString(err)}`);
+    log.error("basic_auth_decode_failed", { error: errorString(err) });
     return { verified: false, payload: null };
   }
 }

--- a/src/authentication-method.ts
+++ b/src/authentication-method.ts
@@ -2,6 +2,7 @@ import { Env } from "..";
 import { newRegistryTokens } from "./token";
 import { UserAuthenticator } from "./user";
 import type { AuthenticatorCredentials } from "./user";
+import { log } from "./log";
 
 export async function authenticationMethodFromEnv(env: Env) {
   if (env.JWT_REGISTRY_TOKENS_PUBLIC_KEY) {
@@ -19,9 +20,10 @@ export async function authenticationMethodFromEnv(env: Env) {
     return new UserAuthenticator(credentials);
   }
 
-  console.error(
-    "Either env.JWT_REGISTRY_TOKENS_PUBLIC_KEY must be set or both env.USERNAME, env.PASSWORD must be set or both env.READONLY_USERNAME, env.READONLY_PASSWORD must be set.",
-  );
+  log.error("auth_method_misconfigured", {
+    hint:
+      "Either env.JWT_REGISTRY_TOKENS_PUBLIC_KEY must be set or both env.USERNAME, env.PASSWORD must be set or both env.READONLY_USERNAME, env.READONLY_PASSWORD must be set.",
+  });
 
   // invalid configuration
   return undefined;

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,6 +1,8 @@
 import { Env } from "..";
 import { InternalError } from "./errors";
 import { Chunk } from "./registry/r2";
+import { errorString } from "./utils";
+import { log } from "./log";
 
 // 5MiB
 export const MINIMUM_CHUNK = 1024 * 1024 * 5;
@@ -135,7 +137,7 @@ export async function* split(
   })()
     .then()
     .catch((err) => {
-      console.log("Error on last identity", err);
+      log.error("chunk_identity_error", { error: errorString(err) });
       throw err;
     });
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,18 @@
+type LogFields = Record<string, string | number | boolean | null | undefined>;
+
+function emit(level: "info" | "warn" | "error", event: string, fields?: LogFields): void {
+  const line = JSON.stringify({ level, event, ts: new Date().toISOString(), ...fields });
+  if (level === "error") {
+    console.error(line);
+  } else if (level === "warn") {
+    console.warn(line);
+  } else {
+    console.log(line);
+  }
+}
+
+export const log = {
+  info: (event: string, fields?: LogFields): void => emit("info", event, fields),
+  warn: (event: string, fields?: LogFields): void => emit("warn", event, fields),
+  error: (event: string, fields?: LogFields): void => emit("error", event, fields),
+};

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -1,6 +1,7 @@
 import { Env } from "../..";
 import { InternalError, ServerError } from "../errors";
 import { errorString } from "../utils";
+import { log } from "../log";
 import { GarbageCollectionMode } from "./garbage-collector";
 import {
   CheckLayerResponse,
@@ -144,11 +145,7 @@ function normalizeReferrersCursor(nextURL: URL, requestURL: URL): string | undef
 function ctxIntoHeaders(ctx: HTTPContext): Headers {
   const headers = new Headers();
   if (ctx.authContext.authType === "none") {
-    console.warn(
-      "Your registry",
-      ctx.authContext.service,
-      "is not using any kind of authentication, making it exposed to the internet",
-    );
+    log.warn("upstream_registry_no_auth", { service: ctx.authContext.service });
     return headers;
   }
 
@@ -208,7 +205,7 @@ function authHeaderIntoAuthContext(urlObject: URL, authenticateHeader: string): 
         authContextOptional[name] = value;
         break;
       default:
-        console.debug(`unknown auth attribute ${name} on registry ${url}`);
+        log.info("auth_attribute_unknown", { name, url });
     }
   });
 
@@ -316,7 +313,7 @@ export class RegistryHTTPClient implements Registry {
 
   async authenticateBearerSimple(ctx: AuthContext, params: URLSearchParams) {
     params.delete("password");
-    console.log("sending authentication parameters:", ctx.realm + "?" + params.toString());
+    log.info("auth_bearer_simple_request", { realm: ctx.realm });
 
     return await fetch(ctx.realm + "?" + params.toString(), {
       headers: {
@@ -345,15 +342,13 @@ export class RegistryHTTPClient implements Registry {
       body: params.toString(),
     });
     if (response.status === 404 || response.status === 405 || response.status == 401) {
-      console.debug(
-        this.url.toString(),
-        "Oauth 404/401/405... Falling back to simple token authentication, see https://distribution.github.io/distribution/spec/auth/token",
-      );
+      log.info("oauth_fallback_triggered", { url: this.url.toString() });
       const responseSimple = await this.authenticateBearerSimple(ctx, params);
       if (responseSimple.ok) {
         response = responseSimple;
       } else {
-        console.error(`Oauth fallback also failed: ${responseSimple.status} ${await responseSimple.text()}`);
+        const fallbackBody = await responseSimple.text();
+        log.error("oauth_fallback_failed", { status: responseSimple.status, body: fallbackBody.slice(0, 100) });
       }
     }
 
@@ -371,16 +366,10 @@ export class RegistryHTTPClient implements Registry {
         repository: string;
         token?: string;
       } = JSON.parse(t);
-      console.debug(
-        `Authenticated with registry ${this.url.toString()} successfully, got token that expires in ${
-          response.expires_in
-        } seconds`,
-      );
+      log.info("oauth_token_acquired", { url: this.url.toString(), expiresIn: response.expires_in });
 
       if (!response.access_token && !response.token) {
-        console.error(
-          "Oauth response doesn't have access_token field, doing fallback to password_env, however this might mean that we will 401 later",
-        );
+        log.error("oauth_response_missing_token", {});
       }
 
       return {
@@ -389,13 +378,7 @@ export class RegistryHTTPClient implements Registry {
         accessToken: response.access_token ?? response.token ?? this.authBase64(),
       };
     } catch (err) {
-      console.error(
-        "Doing json response in authentication: ",
-        errorString(err),
-        t.slice(0, Math.min(t.length, 100)),
-        "status",
-        response.status,
-      );
+      log.error("oauth_json_parse_error", { error: errorString(err), body: t.slice(0, Math.min(t.length, 100)), status: response.status });
       throw err;
     }
   }
@@ -426,13 +409,14 @@ export class RegistryHTTPClient implements Registry {
       req.headers.append("Accept", manifestTypes.join(", "));
       const res = await fetch(req);
       if (!res.ok && res.status !== 404) {
-        console.warn(req.url, "->", res.status, "getting manifest:", await res.text());
+        const manifestBody = await res.text();
+        log.warn("manifest_exists_unexpected_status", { url: req.url, status: res.status, body: manifestBody.slice(0, 100) });
         return {
           response: res,
         };
       }
 
-      console.log("->", req.url, res.status);
+      log.info("manifest_exists_checked", { url: req.url, status: res.status });
       return {
         exists: res.ok,
         digest: res.headers.get("Docker-Content-Digest") as string,
@@ -440,7 +424,7 @@ export class RegistryHTTPClient implements Registry {
         contentType: res.headers.get("Content-Type") ?? "",
       };
     } catch (err) {
-      console.error(`Error doing manifest exists with ${namespace} and ${tag}: ` + errorString(err));
+      log.error("manifest_exists_error", { namespace, tag, error: errorString(err) });
       return {
         response: new InternalError(),
       };
@@ -454,7 +438,7 @@ export class RegistryHTTPClient implements Registry {
       const req = ctxIntoRequest(ctx, this.url, "GET", `${namespace}/manifests/${digest}`);
       req.headers.append("Accept", manifestTypes.join(", "));
       const res = await fetch(req);
-      console.log(req.method, res.status, res.url);
+      log.info("manifest_fetched", { method: req.method, status: res.status, url: res.url });
       if (!res.ok) {
         return {
           response: res,
@@ -472,7 +456,7 @@ export class RegistryHTTPClient implements Registry {
         contentType: res.headers.get("Content-Type") ?? "",
       };
     } catch (err) {
-      console.error(`Error doing get manifest with ${namespace} and ${digest}: ` + errorString(err));
+      log.error("get_manifest_error", { namespace, digest, error: errorString(err) });
       return {
         response: new InternalError(),
       };
@@ -512,7 +496,7 @@ export class RegistryHTTPClient implements Registry {
         digest: res.headers.get("Docker-Content-Digest") ?? digest,
       };
     } catch (err) {
-      console.error(`Error doing layer exists with ${namespace} and ${digest}: ` + errorString(err));
+      log.error("layer_exists_error", { namespace, digest, error: errorString(err) });
       return {
         response: new InternalError(),
       };
@@ -555,7 +539,7 @@ export class RegistryHTTPClient implements Registry {
         digest: res.headers.get("Digest-Content-Digest") ?? digest,
       };
     } catch (err) {
-      console.error(`Error doing get layer with ${namespace} and ${digest}: ` + errorString(err));
+      log.error("get_layer_error", { namespace, digest, error: errorString(err) });
       return {
         response: new InternalError(),
       };
@@ -613,7 +597,7 @@ export class RegistryHTTPClient implements Registry {
       }
 
       const res = await fetch(req);
-      console.log(req.method, res.status, res.url);
+      log.info("referrers_fetched", { method: req.method, status: res.status, url: res.url });
       if (!res.ok) {
         return {
           response: res,
@@ -649,7 +633,7 @@ export class RegistryHTTPClient implements Registry {
         cursor,
       };
     } catch (err) {
-      console.error(`Error doing list referrers with ${namespace} and ${digest}: ` + errorString(err));
+      log.error("list_referrers_error", { namespace, digest, error: errorString(err) });
       return {
         response: new InternalError(),
       };

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -11,7 +11,8 @@ import {
 } from "../chunk";
 import { InternalError, ManifestError, RangeError, ServerError } from "../errors";
 import { SHA256_PREFIX_LEN, getSHA256, hexToDigest, isValidDigest } from "../user";
-import { readableToBlob, readerToBlob, wrap } from "../utils";
+import { errorString, readableToBlob, readerToBlob, wrap } from "../utils";
+import { log } from "../log";
 import { BlobUnknownError, ManifestUnknownError } from "../v2-errors";
 import {
   CheckLayerResponse,
@@ -178,7 +179,7 @@ export async function getJWT(env: Env, state: { registryUploadId: string; name: 
     }
     return metadata.jwt;
   } catch (e) {
-    console.error("Error parsing metadata", e);
+    log.error("metadata_parse_error", { error: errorString(e) });
     return null;
   }
 }
@@ -214,7 +215,7 @@ export async function getUploadState(
   // We are skipping state jwt verifying as it doesn't make sense anymore, we are already verifying it's the latest by looking into R2 and comparing the hash.
   const stateObject = jwt.decode<State>(stateStr).payload;
   if (!stateObject) {
-    console.error("Payload property is not in the JWT");
+    log.error("jwt_payload_missing", {});
     throw new InternalError();
   }
 
@@ -363,7 +364,7 @@ export class R2Registry implements Registry {
         const key = manifestElement.digest;
         const res = await this.env.REGISTRY.head(`${name}/manifests/${key}`);
         if (res === null) {
-          console.error(`Manifest with digest ${key} doesn't exist`);
+          log.error("manifest_digest_missing", { key });
           return new ManifestError("BLOB_UNKNOWN", `unknown manifest ${key}`);
         }
       }
@@ -378,7 +379,7 @@ export class R2Registry implements Registry {
     for (const key of layers) {
       const res = await this.env.REGISTRY.head(`${name}/blobs/${key}`);
       if (res === null) {
-        console.error(`Digest ${key} doesn't exist`);
+        log.error("blob_digest_missing", { key });
         return new ManifestError("BLOB_UNKNOWN", `unknown blob ${key}`);
       }
     }
@@ -554,7 +555,7 @@ export class R2Registry implements Registry {
     }
 
     if (!(await this.gc.checkCanInsertData(name, gcMarker))) {
-      console.error("Manifest can't be uploaded as there is/was a garbage collection going");
+      log.error("manifest_upload_blocked_by_gc", {});
       return { response: new ServerError("garbage collection is on-going... check with registry administrator", 500) };
     }
 
@@ -778,7 +779,7 @@ export class R2Registry implements Registry {
     const urlObject = new URL("https://r2-registry.com" + location);
     const stateHash = urlObject.searchParams.get("_stateHash");
     if (stateHash === null) {
-      console.error("State hash is missing");
+      log.error("state_hash_missing", {});
       return { response: new InternalError() };
     }
 
@@ -803,7 +804,7 @@ export class R2Registry implements Registry {
     }
 
     if (state.parts.length >= 10000) {
-      console.error("We're trying to upload 1k parts");
+      log.error("upload_parts_limit_exceeded", {});
       return { response: new InternalError() };
     }
 
@@ -909,9 +910,7 @@ export class R2Registry implements Registry {
 
       // we know here that size >= MINIMUM_CHUNK and size >= lastChunk.size, this is just super inefficient, maybe in the future just throw RangeError here...
       if (env.PUSH_COMPATIBILITY_MODE === "full" && lastChunk && size >= lastChunk.size) {
-        console.warn(
-          "The client is being a bad citizen by trying to send a new chunk bigger than the chunk it sent. If this is giving problems disable this codepath altogether",
-        );
+        log.warn("chunk_size_regression", {});
         for await (const [chunk, chunkSize] of split(stream, size, lastChunk.size)) {
           await appendStreamKnownLength(chunk, chunkSize);
         }
@@ -927,7 +926,7 @@ export class R2Registry implements Registry {
     };
 
     if (length === undefined) {
-      console.error("Length needs to be defined");
+      log.error("upload_length_missing", {});
       return {
         response: new InternalError(),
       };
@@ -959,7 +958,7 @@ export class R2Registry implements Registry {
     const urlObject = new URL("https://r2-registry.com" + location);
     const stateHash = urlObject.searchParams.get("_stateHash");
     if (stateHash === null) {
-      console.error("State hash is missing");
+      log.error("state_hash_missing", {});
       return { response: new InternalError() };
     }
 
@@ -977,14 +976,14 @@ export class R2Registry implements Registry {
     const uuid = state.registryUploadId;
     if (state.parts.length === 0) {
       if (!stream) {
-        console.error("There has been an upload with zero parts and the body is null");
+        log.error("upload_empty_no_body", {});
         return {
           response: new InternalError(),
         };
       }
 
       if (length && length > MAXIMUM_CHUNK) {
-        console.error("Surpasses MAXIMUM_CHUNK");
+        log.error("chunk_size_exceeds_maximum", {});
         return {
           response: new InternalError(),
         };

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -3,6 +3,7 @@ import { InternalError } from "../errors";
 import { errorString } from "../utils";
 import z from "zod";
 import { GarbageCollectionMode } from "./garbage-collector";
+import { log } from "../log";
 
 // Defines a registry and how it's configured
 const registryConfiguration = z
@@ -33,7 +34,7 @@ export function registries(env: Env): RegistryConfiguration[] {
     const jsonObject = JSON.parse(env.REGISTRIES_JSON);
     return registryConfiguration.array().parse(jsonObject);
   } catch (err) {
-    console.error("Error parsing registries JSON: " + errorString(err));
+    log.error("registries_json_parse_error", { error: errorString(err) });
     return [];
   }
 }
@@ -218,7 +219,7 @@ export interface Registry {
 }
 
 export function wrapError(method: string, err: unknown): RegistryError {
-  console.error(method, "error:", errorString(err));
+  log.error("registry_operation_error", { method, error: errorString(err) });
   return {
     response: new InternalError(),
   };

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,6 +5,7 @@ import { errorString, jsonHeaders, wrap } from "./utils";
 import { hexToDigest, isValidDigest } from "./user";
 import { ManifestTagsListTooBigError } from "./v2-responses";
 import { Env } from "..";
+import { log } from "./log";
 import { MINIMUM_CHUNK, MAXIMUM_CHUNK, MAXIMUM_CHUNK_UPLOAD_SIZE } from "./chunk";
 import {
   CheckLayerResponse,
@@ -173,10 +174,7 @@ v2Router.head("/:name+/manifests/:reference", async (req, env: Env) => {
       if ("exists" in res && !res.exists) {
         const manifestResponse = await client.getManifest(name, response.digest);
         if ("response" in manifestResponse) {
-          console.warn(
-            "Can't sync with fallback registry because it has returned an error:",
-            manifestResponse.response.status,
-          );
+          log.warn("manifest_fallback_sync_failed", { status: manifestResponse.response.status });
           break;
         }
 
@@ -187,11 +185,11 @@ v2Router.head("/:name+/manifests/:reference", async (req, env: Env) => {
           }),
         );
         if (err) {
-          console.error("Error sync manifest into client:", errorString(err));
+          log.error("manifest_sync_error", { error: errorString(err) });
         }
 
         if (putResponse && "response" in putResponse) {
-          console.error("Error sync manifest into client (non 200 status):", putResponse.response.status);
+          log.error("manifest_sync_failed", { status: putResponse.response.status });
         }
       }
 
@@ -250,12 +248,12 @@ v2Router.get("/:name+/manifests/:reference", async (req, env: Env, context: Exec
           }),
         );
         if (err) {
-          console.error("Error uploading asynchronously the manifest ", reference, "into main registry");
+          log.error("manifest_async_upload_error", { reference });
           return;
         }
 
         if (response && "response" in response) {
-          console.error("Error uploading asynchronously manifest:", response.response.status);
+          log.error("manifest_async_upload_failed", { status: response.response.status });
         }
       })(),
     );
@@ -284,7 +282,7 @@ v2Router.put("/:name+/manifests/:reference", async (req, env: Env) => {
     env.REGISTRY_CLIENT.putManifest(name, reference, req.body!, { contentType: req.headers.get("Content-Type")! }),
   );
   if (err) {
-    console.error("Error putting manifest:", errorString(err));
+    log.error("put_manifest_error", { error: errorString(err) });
     return new InternalError();
   }
 
@@ -386,12 +384,12 @@ v2Router.get("/:name+/blobs/:digest", async (req, env: Env, context: ExecutionCo
       (async () => {
         const [response, err] = await wrap(env.REGISTRY_CLIENT.monolithicUpload(name, digest, s2, layerResponse.size));
         if (err) {
-          console.error("Error uploading asynchronously the layer ", digest, "into main registry");
+          log.error("layer_async_upload_error", { digest });
           return;
         }
 
         if (response === false) {
-          console.error("Layer might be too big for the registry client", layerResponse.size);
+          log.error("layer_too_big", { size: layerResponse.size });
         }
       })(),
     );
@@ -412,7 +410,7 @@ v2Router.delete("/:name+/blobs/uploads/:id", async (req, env: Env) => {
   const { name, id } = req.params;
   const [res, err] = await wrap<true | RegistryError, Error>(env.REGISTRY_CLIENT.cancelUpload(name, id));
   if (err) {
-    console.error("Error cancelling upload:", errorString(err));
+    log.error("cancel_upload_error", { error: errorString(err) });
     return new InternalError();
   }
 
@@ -533,7 +531,7 @@ v2Router.patch("/:name+/blobs/uploads/:uuid", async (req, env: Env) => {
     ),
   );
   if (err) {
-    console.error("Uploading chunk:", errorString(err));
+    log.error("chunk_upload_error", { error: errorString(err) });
     return new InternalError();
   }
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -125,14 +125,22 @@ export class RegistryTokens implements Authenticator {
       case "HEAD":
         // HEAD requests can be used by pushers like docker
         if (!payload.capabilities.includes("pull") && !payload.capabilities.includes("push")) {
-          log.warn("jwt_capability_denied", { method: request.method, url: request.url, reason: "missing_any_capability" });
+          log.warn("jwt_capability_denied", {
+            method: request.method,
+            url: request.url,
+            reason: "missing_any_capability",
+          });
           return { verified: false, payload: null };
         }
         break;
       // PULL method
       case "GET":
         if (this.checkIfV2OnlyPath(request) && payload.capabilities.length === 0) {
-          log.warn("jwt_capability_denied", { method: request.method, url: request.url, reason: "no_capabilities_for_v2" });
+          log.warn("jwt_capability_denied", {
+            method: request.method,
+            url: request.url,
+            reason: "no_capabilities_for_v2",
+          });
           return { verified: false, payload: null };
         }
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -6,6 +6,7 @@ import {
   stripUsernamePasswordFromHeader,
   Authenticator,
 } from "./auth";
+import { log } from "./log";
 
 export function importKeyFromBase64(key: string): JsonWebKeyWithKid {
   // Decodes the base64 value and performs unicode normalization.
@@ -90,7 +91,7 @@ export class RegistryTokens implements Authenticator {
     try {
       // first verify the JWT
       if (!(await jwt.verify(token, this.jwtPublicKey, { algorithm: "ES256" }))) {
-        console.warn("verifyToken: jwt.verify() failed");
+        log.warn("jwt_verify_failed", { reason: "signature_invalid" });
         return { verified: false, payload: null };
       }
 
@@ -104,7 +105,7 @@ export class RegistryTokens implements Authenticator {
 
       // We could throw this error further up to allow more specific error handling,
       // or simply return {verified: false, payload: null  }to indicate token verification failure.
-      console.warn(`verifyToken: ${(error as Error).message}`);
+      log.warn("jwt_verify_error", { message: (error as Error).message });
       return { verified: false, payload: null };
     }
   }
@@ -114,7 +115,7 @@ export class RegistryTokens implements Authenticator {
     const now = Math.floor(Date.now() / 1000);
     if (payload.exp && now >= payload.exp) {
       // The token has expired
-      console.warn(`verifyV0Token: failed jwt verification: the token has expired`);
+      log.warn("jwt_expired", { exp: payload.exp ?? null });
       return { verified: false, payload: null };
     }
 
@@ -124,16 +125,14 @@ export class RegistryTokens implements Authenticator {
       case "HEAD":
         // HEAD requests can be used by pushers like docker
         if (!payload.capabilities.includes("pull") && !payload.capabilities.includes("push")) {
-          console.warn(
-            `verifyToken: failed jwt verification: missing any capability for HEAD request in ${request.url}`,
-          );
+          log.warn("jwt_capability_denied", { method: request.method, url: request.url, reason: "missing_any_capability" });
           return { verified: false, payload: null };
         }
         break;
       // PULL method
       case "GET":
         if (this.checkIfV2OnlyPath(request) && payload.capabilities.length === 0) {
-          console.warn("verifyToken: failed jwt verification: missing any capabilities for GET request in /v2/");
+          log.warn("jwt_capability_denied", { method: request.method, url: request.url, reason: "no_capabilities_for_v2" });
           return { verified: false, payload: null };
         }
 
@@ -142,9 +141,7 @@ export class RegistryTokens implements Authenticator {
         }
 
         if (!payload.capabilities.includes("pull")) {
-          console.warn(
-            `verifyToken: failed jwt verification: missing "pull" capability for ${request.method} HTTP method in ${request.url}`,
-          );
+          log.warn("jwt_capability_denied", { method: request.method, url: request.url, required: "pull" });
           return { verified: false, payload: null };
         }
         break;
@@ -155,9 +152,7 @@ export class RegistryTokens implements Authenticator {
       case "DELETE":
       case "PATCH":
         if (!payload.capabilities.includes("push")) {
-          console.warn(
-            `verifyToken: failed jwt verification: missing "push" capability for ${request.method} HTTP method`,
-          );
+          log.warn("jwt_capability_denied", { method: request.method, required: "push" });
           return { verified: false, payload: null };
         }
         break;

--- a/src/user.ts
+++ b/src/user.ts
@@ -2,6 +2,7 @@ import { Authenticator, AuthenticatorCheckCredentialsResponse, stripUsernamePass
 import { errorString } from "./utils";
 import { RegistryTokens } from "./token";
 import type { RegistryTokenCapability } from "./auth";
+import { log } from "./log";
 
 export const SHA256_PREFIX = "sha256";
 export const SHA256_PREFIX_LEN = SHA256_PREFIX.length + 1; // add ":"
@@ -88,7 +89,7 @@ export class UserAuthenticator implements Authenticator {
         return { verified: false, payload: null };
       }
     } catch (err) {
-      console.error(`Failed authentication timingSafeEqual: ${errorString(err)}`);
+      log.error("timing_safe_equal_error", { error: errorString(err) });
       return { verified: false, payload: null };
     }
 

--- a/test/auth-logging.test.ts
+++ b/test/auth-logging.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test, vi } from "vitest";
+import { stripUsernamePasswordFromHeader } from "../src/auth";
+import { RegistryTokens, newRegistryTokens } from "../src/token";
+
+describe("auth structured logging", () => {
+  test("stripUsernamePasswordFromHeader logs a structured error on malformed Basic credentials", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const request = new Request("https://registry.com/v2/", {
+      headers: { Authorization: "Basic !!!not-valid-base64!!!" },
+    });
+
+    const result = stripUsernamePasswordFromHeader(request);
+
+    expect(result).toEqual({ verified: false, payload: null });
+    expect(errorSpy).toHaveBeenCalled();
+    const logged = JSON.parse(errorSpy.mock.calls.at(-1)![0] as string);
+    expect(logged).toMatchObject({ level: "error", event: "basic_auth_decode_failed" });
+
+    errorSpy.mockRestore();
+  });
+});
+
+describe("token structured logging", () => {
+  test("verifyToken logs a structured warning when the token cannot be parsed", async () => {
+    const [, publicKey] = await RegistryTokens.createPrivateAndPublicKey();
+    const registryTokens = await newRegistryTokens(publicKey);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await registryTokens.verifyToken(new Request("https://registry.com/v2/"), "not-a-real-jwt");
+
+    expect(result.verified).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    const logged = JSON.parse(warnSpy.mock.calls.at(-1)![0] as string);
+    expect(logged).toMatchObject({ level: "warn", event: "jwt_verify_error" });
+
+    warnSpy.mockRestore();
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1299,25 +1299,25 @@ test("registries configuration", async () => {
     {
       configuration: "{}",
       expected: [],
-      error: "Error parsing registries JSON: zod error:\n✖ Invalid input: expected array, received object",
-      partialError: false,
+      error: '"event":"registries_json_parse_error"',
+      partialError: true,
     },
     {
       configuration: "[{}]",
       expected: [],
-      error: "✖ Invalid input: expected string, received undefined\n  → at [0].registry",
+      error: '"event":"registries_json_parse_error"',
       partialError: true,
     },
     {
       configuration: `[{ "registry": "no-url/hello-world" }]`,
       expected: [],
-      error: "✖ Invalid URL\n  → at [0].registry",
+      error: '"event":"registries_json_parse_error"',
       partialError: true,
     },
     {
       configuration: "bla bla bla no json",
       expected: [],
-      error: "Error parsing registries JSON: error SyntaxError: Unexpected token",
+      error: '"event":"registries_json_parse_error"',
       partialError: true,
     },
     {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1299,25 +1299,25 @@ test("registries configuration", async () => {
     {
       configuration: "{}",
       expected: [],
-      error: '"event":"registries_json_parse_error"',
-      partialError: true,
+      error: "zod error:\n✖ Invalid input: expected array, received object",
+      partialError: false,
     },
     {
       configuration: "[{}]",
       expected: [],
-      error: '"event":"registries_json_parse_error"',
+      error: "✖ Invalid input: expected string, received undefined\n  → at [0].registry",
       partialError: true,
     },
     {
       configuration: `[{ "registry": "no-url/hello-world" }]`,
       expected: [],
-      error: '"event":"registries_json_parse_error"',
+      error: "✖ Invalid URL\n  → at [0].registry",
       partialError: true,
     },
     {
       configuration: "bla bla bla no json",
       expected: [],
-      error: '"event":"registries_json_parse_error"',
+      error: "error SyntaxError: Unexpected token",
       partialError: true,
     },
     {
@@ -1383,10 +1383,12 @@ test("registries configuration", async () => {
     let calledError = false;
     const prevConsoleError = console.error;
     console.error = (output) => {
+      const parsed = JSON.parse(output as string);
+      expect(parsed).toMatchObject({ level: "error", event: "registries_json_parse_error" });
       if (!testCase.partialError) {
-        expect(output).toEqual(testCase.error);
+        expect(parsed.error).toEqual(testCase.error);
       } else {
-        expect(output).toContain(testCase.error);
+        expect(parsed.error).toContain(testCase.error);
       }
 
       calledError = true;

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from "vitest";
+import { log } from "../src/log";
+
+describe("log", () => {
+  test("info emits a structured JSON line via console.log", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    log.info("test_event", { foo: "bar" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({ level: "info", event: "test_event", foo: "bar" });
+    expect(typeof parsed.ts).toBe("string");
+
+    spy.mockRestore();
+  });
+
+  test("warn emits a structured JSON line via console.warn", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    log.warn("auth_denied", { authmode: "basic" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({ level: "warn", event: "auth_denied", authmode: "basic" });
+
+    spy.mockRestore();
+  });
+
+  test("error emits a structured JSON line via console.error", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    log.error("unhandled_error", { message: "boom" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({ level: "error", event: "unhandled_error", message: "boom" });
+
+    spy.mockRestore();
+  });
+
+  test("omitted fields still produce a valid structured line", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    log.info("no_fields_event");
+
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({ level: "info", event: "no_fields_event" });
+
+    spy.mockRestore();
+  });
+});

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import worker from "../index";
+import type { Env } from "..";
+import { env } from "cloudflare:workers";
+import { createExecutionContext, reset, waitOnExecutionContext } from "cloudflare:test";
+
+afterEach(async () => {
+  await reset();
+});
+
+function createRequest(method: string, path: string, headers: Record<string, string> = {}): Request {
+  return new Request(new URL("https://registry.com" + path), { method, headers });
+}
+
+function basicAuth(username: string, password: string): string {
+  return `Basic ${btoa(`${username}:${password}`)}`;
+}
+
+describe("observability", () => {
+  test("emits a structured warn log and a failure metric on denied auth", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const bindings = env as Env;
+    const metricsSpy = vi.spyOn(bindings.METRICS!, "writeDataPoint");
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      createRequest("GET", "/v2/", { Authorization: basicAuth("hello", "wrong") }),
+      bindings,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(401);
+
+    expect(warnSpy).toHaveBeenCalled();
+    const logged = JSON.parse(warnSpy.mock.calls.at(-1)![0] as string);
+    expect(logged).toMatchObject({ level: "warn", event: "auth_denied" });
+
+    expect(metricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ blobs: ["registry", "auth_denied"], indexes: ["401"] }),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  test("emits a success metric on a successful request", async () => {
+    const bindings = env as Env;
+    const metricsSpy = vi.spyOn(bindings.METRICS!, "writeDataPoint");
+
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      createRequest("GET", "/v2/", { Authorization: basicAuth("hello", "world") }),
+      bindings,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(metricsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ blobs: ["registry", "success"], indexes: ["200"] }),
+    );
+  });
+});

--- a/test/wrangler.test.toml
+++ b/test/wrangler.test.toml
@@ -10,11 +10,15 @@ compatibility_flags = ["nodejs_compat"]
 r2_buckets = [
   { binding = "REGISTRY", bucket_name = "" }
 ]
+analytics_engine_datasets = [
+  { binding = "METRICS", dataset = "dp_artifact_metrics" }
+]
 
 [env.production.vars]
 JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
 [env.dev]
 r2_buckets = [{ binding = "REGISTRY", bucket_name = "r2-image-registry-dev" }]
+analytics_engine_datasets = [{ binding = "METRICS", dataset = "dp_artifact_metrics_dev" }]
 
 [env.dev.vars]
 USERNAME = "hello"

--- a/wrangler.toml.example
+++ b/wrangler.toml.example
@@ -15,6 +15,9 @@ compatibility_flags = ["nodejs_compat"]
 r2_buckets = [
   { binding = "REGISTRY", bucket_name = "" }
 ]
+analytics_engine_datasets = [
+  { binding = "METRICS", dataset = "dp_artifact_metrics" }
+]
 
 [env.production.vars]
 JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
@@ -26,6 +29,7 @@ JWT_REGISTRY_TOKENS_PUBLIC_KEY = ""
 ## Dev - For local dev using `npx wrangler dev`
 [env.dev]
 r2_buckets = [{ binding = "REGISTRY", bucket_name = "r2-image-registry-dev" }]
+analytics_engine_datasets = [{ binding = "METRICS", dataset = "dp_artifact_metrics_dev" }]
 [env.dev.vars]
 # REGISTRIES_JSON = "[{ \"registry\": \"http://localhost:9999\", \"password_env\": \"PASSWORD\", \"username\": \"hello\" }]"
 USERNAME = "hello"


### PR DESCRIPTION
## Summary

Adds structured JSON logging (`src/log.ts`) and per-request Analytics Engine metrics to the registry Worker, replacing every scattered `console.*` call in `src/` with a consistent `log.info`/`log.warn`/`log.error` API.

- `src/log.ts`: thin structured-logging wrapper (Task 1)
- `index.ts`: `METRICS` Analytics Engine binding + per-request metric (Task 2)
- `src/router.ts`, `src/auth.ts`, `src/token.ts`, `src/authentication-method.ts`, `src/chunk.ts`: logging conversions (Tasks 3-5)
- `src/registry/r2.ts`, `src/registry/http.ts`, `src/registry/registry.ts`, `src/user.ts`: logging conversions (Tasks 13-15, added after a first whole-branch review found the original scope incomplete)

Companion PR in `devprod-infra` wires the matching Terraform `METRICS` binding, an alerting Worker, and a push-event monitoring Worker for non-container artifacts: see DEVPROD-4153.

Full design/plan: `~/notes/plans/2026-07-02-registry-observability.md`.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm test` — 65/65 passing
- [x] Every task individually reviewed (spec compliance + code quality); one round of fixes applied and re-reviewed (test-rigor regression in `test/index.test.ts`, caught and fixed)
- [x] Final whole-branch review: "Ready to merge? Yes" — confirmed live via `grep -rn "console\." src/` that only `src/log.ts`'s own implementation and one JSDoc example remain
