### PR TITLE
Fix #64, add range header forwarding

### DIFF
--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -17,6 +17,7 @@ import {
   RegistryError,
   UploadId,
   UploadObject,
+  BlobRangeRequest,
 } from "./registry";
 import { ociImageIndexContentType } from "./r2";
 
@@ -156,16 +157,39 @@ function ctxIntoHeaders(ctx: HTTPContext): Headers {
   return headers;
 }
 
-function ctxIntoRequest(ctx: HTTPContext, url: URL, method: string, path: string, body?: BodyInit): Request {
+function ctxIntoRequest(
+  ctx: HTTPContext,
+  url: URL,
+  method: string,
+  path: string,
+  body?: BodyInit,
+  extraHeaders?: HeadersInit,
+): Request {
   const urlReq = `${url.protocol}//${url.host}/v2${
     ctx.repository === "" || ctx.repository === "/" ? "/" : ctx.repository + "/"
   }${path}`;
+  const headers = ctxIntoHeaders(ctx);
+  if (extraHeaders !== undefined) {
+    new Headers(extraHeaders).forEach((value, key) => headers.set(key, value));
+  }
   return new Request(urlReq, {
     method,
     body,
     redirect: "follow",
-    headers: ctxIntoHeaders(ctx),
+    headers,
   });
+}
+
+// Parses an HTTP "Content-Range: bytes <start>-<end>/<size>" response header.
+function parseContentRange(header: string | null): { start: number; end: number; size: number } | null {
+  if (header === null) return null;
+  const match = /^bytes (\d+)-(\d+)\/(\d+)$/.exec(header.trim());
+  if (match === null) return null;
+  const start = Number(match[1]);
+  const end = Number(match[2]);
+  const size = Number(match[3]);
+  if (!Number.isInteger(start) || !Number.isInteger(end) || !Number.isInteger(size)) return null;
+  return { start, end, size };
 }
 
 function authHeaderIntoAuthContext(urlObject: URL, authenticateHeader: string): AuthContext {
@@ -519,18 +543,29 @@ export class RegistryHTTPClient implements Registry {
     }
   }
 
-  async getLayer(name: string, digest: string): Promise<GetLayerResponse | RegistryError> {
+  async getLayer(name: string, digest: string, range?: BlobRangeRequest): Promise<GetLayerResponse | RegistryError> {
     const namespace = name.includes("/") || !isDockerDotIO(this.url) ? name : `library/${name}`;
     try {
       const ctx = await this.authenticate(namespace);
-      const req = ctxIntoRequest(ctx, this.url, "GET", `${namespace}/blobs/${digest}`);
+      const rangeHeader =
+        range === undefined ? undefined : `bytes=${range.offset}-${range.end === undefined ? "" : range.end}`;
+      const req = ctxIntoRequest(
+        ctx,
+        this.url,
+        "GET",
+        `${namespace}/blobs/${digest}`,
+        undefined,
+        rangeHeader !== undefined ? { Range: rangeHeader } : undefined,
+      );
       let res = await fetch(req);
       if (!res.ok) {
         // This means we got a redirect, so let's try again this URL but
         // without any headers. Services like S3 reject authorization headers altogether
         // if the authentication is included in the URL.
         if (res.url !== req.url) {
-          const redirectResponse = await fetch(new Request(res.url));
+          const redirectResponse = await fetch(
+            new Request(res.url, rangeHeader !== undefined ? { headers: { Range: rangeHeader } } : undefined),
+          );
           if (!redirectResponse.ok) {
             return {
               response: res,
@@ -549,11 +584,27 @@ export class RegistryHTTPClient implements Registry {
         throw new Error("returned body is null");
       }
 
-      return {
+      const layer: GetLayerResponse = {
         stream: res.body,
         size: +(res.headers.get("Content-Length") ?? "0"),
         digest: res.headers.get("Digest-Content-Digest") ?? digest,
       };
+
+      // If we asked for a range and the upstream honored it, surface the partial-content metadata so
+      // the caller can reply with 206. A 200 here means the upstream ignored the range and we serve
+      // the full blob (best-effort). Serving a partial body as if it were complete would corrupt it,
+      // so a 206 without a parseable Content-Range is treated as an error.
+      if (range !== undefined && res.status === 206) {
+        const contentRange = parseContentRange(res.headers.get("Content-Range"));
+        if (contentRange === null) {
+          throw new Error("upstream returned 206 without a parseable Content-Range header");
+        }
+
+        layer.size = contentRange.size;
+        layer.contentRange = contentRange;
+      }
+
+      return layer;
     } catch (err) {
       console.error(`Error doing get layer with ${namespace} and ${digest}: ` + errorString(err));
       return {

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -180,6 +180,15 @@ function ctxIntoRequest(
   });
 }
 
+// Serializes a blob range request into an HTTP "Range" request header value.
+function rangeRequestHeader(range: BlobRangeRequest): string {
+  if ("suffix" in range) {
+    return `bytes=-${range.suffix}`;
+  }
+
+  return `bytes=${range.offset}-${range.end === undefined ? "" : range.end}`;
+}
+
 // Parses an HTTP "Content-Range: bytes <start>-<end>/<size>" response header.
 function parseContentRange(header: string | null): { start: number; end: number; size: number } | null {
   if (header === null) return null;
@@ -547,8 +556,7 @@ export class RegistryHTTPClient implements Registry {
     const namespace = name.includes("/") || !isDockerDotIO(this.url) ? name : `library/${name}`;
     try {
       const ctx = await this.authenticate(namespace);
-      const rangeHeader =
-        range === undefined ? undefined : `bytes=${range.offset}-${range.end === undefined ? "" : range.end}`;
+      const rangeHeader = range === undefined ? undefined : rangeRequestHeader(range);
       const req = ctxIntoRequest(
         ctx,
         this.url,

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -28,11 +28,22 @@ import {
   UploadId,
   UploadObject,
   wrapError,
+  BlobRangeRequest,
 } from "./registry";
 import { GarbageCollectionMode, GarbageCollector } from "./garbage-collector";
 import { ManifestSchema, manifestSchema } from "../manifest";
 
 export const ociImageIndexContentType = "application/vnd.oci.image.index.v1+json";
+
+function rangeNotSatisfiableResponse(size: number): Response {
+  return new Response(null, {
+    status: 416,
+    headers: {
+      "Content-Range": `bytes */${size}`,
+      "Accept-Ranges": "bytes",
+    },
+  });
+}
 
 function referrersPrefix(name: string, digest: string): string {
   return `${name}/_referrers/${digest}/`;
@@ -690,8 +701,78 @@ export class R2Registry implements Registry {
     };
   }
 
-  async getLayer(name: string, digest: string): Promise<RegistryError | GetLayerResponse> {
-    const [res, err] = await wrap(this.env.REGISTRY.get(`${name}/blobs/${digest}`));
+  async getLayer(
+    name: string,
+    digest: string,
+    range?: BlobRangeRequest,
+  ): Promise<RegistryError | GetLayerResponse> {
+    const key = `${name}/blobs/${digest}`;
+
+    if (range === undefined) {
+      const [res, err] = await wrap(this.env.REGISTRY.get(key));
+      if (err) {
+        return wrapError("getLayer", err);
+      }
+
+      if (!res) {
+        return {
+          response: new Response(JSON.stringify(BlobUnknownError), { status: 404 }),
+        };
+      }
+
+      // Handle R2 symlink
+      if (res.customMetadata && symlinkHeader in res.customMetadata) {
+        return await this.followLayerSymlink(name, digest, res, undefined);
+      }
+
+      return {
+        stream: res.body!,
+        digest: hexToDigest(res.checksums.sha256!),
+        size: res.size,
+      };
+    }
+
+    // Ranged read: inspect object metadata first so we can validate the requested range and
+    // resolve symlinks without streaming the full object.
+    const [head, headErr] = await wrap(this.env.REGISTRY.head(key));
+    if (headErr) {
+      return wrapError("getLayer", headErr);
+    }
+
+    if (!head) {
+      return {
+        response: new Response(JSON.stringify(BlobUnknownError), { status: 404 }),
+      };
+    }
+
+    if (head.customMetadata && symlinkHeader in head.customMetadata) {
+      const [link, linkErr] = await wrap(this.env.REGISTRY.get(key));
+      if (linkErr) {
+        return wrapError("getLayer", linkErr);
+      }
+
+      if (!link) {
+        return {
+          response: new Response(JSON.stringify(BlobUnknownError), { status: 404 }),
+        };
+      }
+
+      return await this.followLayerSymlink(name, digest, link, range);
+    }
+
+    const totalSize = head.size;
+    const start = range.offset;
+    if (start < 0 || start >= totalSize) {
+      return { response: rangeNotSatisfiableResponse(totalSize) };
+    }
+
+    const end = range.end === undefined ? totalSize - 1 : Math.min(range.end, totalSize - 1);
+    if (end < start) {
+      return { response: rangeNotSatisfiableResponse(totalSize) };
+    }
+
+    const length = end - start + 1;
+    const [res, err] = await wrap(this.env.REGISTRY.get(key, { range: { offset: start, length } }));
     if (err) {
       return wrapError("getLayer", err);
     }
@@ -702,24 +783,29 @@ export class R2Registry implements Registry {
       };
     }
 
-    // Handle R2 symlink
-    if (res.customMetadata && symlinkHeader in res.customMetadata) {
-      const layerPath = await res.text();
-      // Symlink detected! Will download layer from "layerPath"
-      const [linkName, linkDigest] = layerPath.split("/blobs/");
-      if (linkName == name && linkDigest == digest) {
-        return {
-          response: new Response(JSON.stringify(BlobUnknownError), { status: 404 }),
-        };
-      }
-      return await this.env.REGISTRY_CLIENT.getLayer(linkName, linkDigest);
-    }
-
     return {
       stream: res.body!,
-      digest: hexToDigest(res.checksums.sha256!),
-      size: res.size,
+      digest: hexToDigest(head.checksums.sha256!),
+      size: totalSize,
+      contentRange: { start, end, size: totalSize },
     };
+  }
+
+  private async followLayerSymlink(
+    name: string,
+    digest: string,
+    object: R2ObjectBody,
+    range: BlobRangeRequest | undefined,
+  ): Promise<RegistryError | GetLayerResponse> {
+    const layerPath = await object.text();
+    // Symlink detected! Will download layer from "layerPath"
+    const [linkName, linkDigest] = layerPath.split("/blobs/");
+    if (linkName == name && linkDigest == digest) {
+      return {
+        response: new Response(JSON.stringify(BlobUnknownError), { status: 404 }),
+      };
+    }
+    return await this.env.REGISTRY_CLIENT.getLayer(linkName, linkDigest, range);
   }
 
   async startUpload(namespace: string): Promise<RegistryError | UploadObject> {

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -761,14 +761,27 @@ export class R2Registry implements Registry {
     }
 
     const totalSize = head.size;
-    const start = range.offset;
-    if (start < 0 || start >= totalSize) {
-      return { response: rangeNotSatisfiableResponse(totalSize) };
-    }
+    let start: number;
+    let end: number;
+    if ("suffix" in range) {
+      // A suffix longer than the object is satisfied by the whole object, but a zero-length suffix
+      // selects no bytes at all and cannot be satisfied.
+      if (range.suffix <= 0 || totalSize === 0) {
+        return { response: rangeNotSatisfiableResponse(totalSize) };
+      }
 
-    const end = range.end === undefined ? totalSize - 1 : Math.min(range.end, totalSize - 1);
-    if (end < start) {
-      return { response: rangeNotSatisfiableResponse(totalSize) };
+      start = Math.max(totalSize - range.suffix, 0);
+      end = totalSize - 1;
+    } else {
+      start = range.offset;
+      if (start < 0 || start >= totalSize) {
+        return { response: rangeNotSatisfiableResponse(totalSize) };
+      }
+
+      end = range.end === undefined ? totalSize - 1 : Math.min(range.end, totalSize - 1);
+      if (end < start) {
+        return { response: rangeNotSatisfiableResponse(totalSize) };
+      }
     }
 
     const length = end - start + 1;

--- a/src/registry/r2.ts
+++ b/src/registry/r2.ts
@@ -701,11 +701,7 @@ export class R2Registry implements Registry {
     };
   }
 
-  async getLayer(
-    name: string,
-    digest: string,
-    range?: BlobRangeRequest,
-  ): Promise<RegistryError | GetLayerResponse> {
+  async getLayer(name: string, digest: string, range?: BlobRangeRequest): Promise<RegistryError | GetLayerResponse> {
     const key = `${name}/blobs/${digest}`;
 
     if (range === undefined) {

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -99,11 +99,19 @@ export type GetManifestResponse = {
   contentType: string;
 };
 
+// requested byte range for a layer read (inclusive end; end omitted means until the end of the object)
+export type BlobRangeRequest = {
+  offset: number;
+  end?: number;
+};
+
 // returned by getLayer when it successfully retrieves a layer
 export type GetLayerResponse = {
   stream: ReadableStream;
   digest: string;
   size: number;
+  // present when the response is a partial (ranged) read, drives the 206 Partial Content response
+  contentRange?: { start: number; end: number; size: number };
 };
 
 export type ReferrerDescriptor = {
@@ -150,7 +158,7 @@ export interface Registry {
   layerExists(namespace: string, digest: string): Promise<CheckLayerResponse | RegistryError>;
 
   // get a layer stream from the registry
-  getLayer(namespace: string, digest: string): Promise<GetLayerResponse | RegistryError>;
+  getLayer(namespace: string, digest: string, range?: BlobRangeRequest): Promise<GetLayerResponse | RegistryError>;
 
   // list referrers for a subject digest
   listReferrers(

--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -99,11 +99,9 @@ export type GetManifestResponse = {
   contentType: string;
 };
 
-// requested byte range for a layer read (inclusive end; end omitted means until the end of the object)
-export type BlobRangeRequest = {
-  offset: number;
-  end?: number;
-};
+// requested byte range for a layer read. Either an offset with an inclusive end (end omitted means
+// until the end of the object), or a suffix asking for the last N bytes of the object.
+export type BlobRangeRequest = { offset: number; end?: number } | { suffix: number };
 
 // returned by getLayer when it successfully retrieves a layer
 export type GetLayerResponse = {

--- a/src/router.ts
+++ b/src/router.ts
@@ -406,27 +406,33 @@ v2Router.get("/:name+/blobs/:digest", async (req, env: Env, context: ExecutionCo
   const registriesList = registries(env);
   for (const registry of registriesList) {
     const client = new RegistryHTTPClient(env, registry);
-    const response = await client.getLayer(name, digest);
+    const response = await client.getLayer(name, digest, range);
     if ("response" in response) {
       continue;
     }
 
     layerResponse = response;
-    const [s1, s2] = layerResponse.stream.tee();
-    layerResponse.stream = s1;
-    context.waitUntil(
-      (async () => {
-        const [response, err] = await wrap(env.REGISTRY_CLIENT.monolithicUpload(name, digest, s2, layerResponse.size));
-        if (err) {
-          console.error("Error uploading asynchronously the layer ", digest, "into main registry");
-          return;
-        }
+    // Only cache full-object responses. A ranged/partial upstream response must never be written to
+    // R2 as if it were the complete blob, or the cached object would be corrupt.
+    if (range === undefined && layerResponse.contentRange === undefined) {
+      const fullLayer = layerResponse;
+      const [s1, s2] = fullLayer.stream.tee();
+      fullLayer.stream = s1;
+      context.waitUntil(
+        (async () => {
+          const [response, err] = await wrap(env.REGISTRY_CLIENT.monolithicUpload(name, digest, s2, fullLayer.size));
+          if (err) {
+            console.error("Error uploading asynchronously the layer ", digest, "into main registry");
+            return;
+          }
 
-        if (response === false) {
-          console.error("Layer might be too big for the registry client", layerResponse.size);
-        }
-      })(),
-    );
+          if (response === false) {
+            console.error("Layer might be too big for the registry client", fullLayer.size);
+          }
+        })(),
+      );
+    }
+
     break;
   }
 

--- a/src/router.ts
+++ b/src/router.ts
@@ -358,16 +358,48 @@ v2Router.get("/:name+/referrers/:digest", async (req, env: Env) => {
   );
 });
 
+// Parses a single HTTP byte range request of the form "bytes=<start>-" or "bytes=<start>-<end>".
+// Multi-range, suffix ("bytes=-<n>") and malformed values are ignored so the full object is served.
+function parseBlobRange(header: string | null): { offset: number; end?: number } | undefined {
+  if (header === null) return undefined;
+  const match = /^bytes=(\d+)-(\d*)$/.exec(header.trim());
+  if (match === null) return undefined;
+  const offset = Number(match[1]);
+  if (!Number.isInteger(offset)) return undefined;
+  if (match[2] === "") return { offset };
+  const end = Number(match[2]);
+  if (!Number.isInteger(end)) return { offset };
+  return { offset, end };
+}
+
+function blobGetResponse(layer: GetLayerResponse): Response {
+  const headers: Record<string, string> = {
+    "Docker-Content-Digest": layer.digest,
+    "Accept-Ranges": "bytes",
+  };
+  if (layer.contentRange !== undefined) {
+    const { start, end, size } = layer.contentRange;
+    headers["Content-Length"] = `${end - start + 1}`;
+    headers["Content-Range"] = `bytes ${start}-${end}/${size}`;
+    return new Response(layer.stream, { status: 206, headers });
+  }
+
+  headers["Content-Length"] = `${layer.size}`;
+  return new Response(layer.stream, { headers });
+}
+
 v2Router.get("/:name+/blobs/:digest", async (req, env: Env, context: ExecutionContext) => {
   const { name, digest } = req.params;
-  const res = await env.REGISTRY_CLIENT.getLayer(name, digest);
+  const range = parseBlobRange(req.headers.get("range"));
+  const res = await env.REGISTRY_CLIENT.getLayer(name, digest, range);
   if (!("response" in res)) {
-    return new Response(res.stream, {
-      headers: {
-        "Docker-Content-Digest": res.digest,
-        "Content-Length": `${res.size}`,
-      },
-    });
+    return blobGetResponse(res);
+  }
+
+  // A requested range that cannot be satisfied is reported directly instead of falling back to
+  // other registries.
+  if (res.response.status === 416) {
+    return res.response;
   }
 
   let layerResponse: GetLayerResponse | null = null;
@@ -400,12 +432,7 @@ v2Router.get("/:name+/blobs/:digest", async (req, env: Env, context: ExecutionCo
 
   if (layerResponse === null) return new Response(JSON.stringify(BlobUnknownError), { status: 404 });
 
-  return new Response(layerResponse.stream, {
-    headers: {
-      "Docker-Content-Digest": layerResponse.digest,
-      "Content-Length": `${layerResponse.size}`,
-    },
-  });
+  return blobGetResponse(layerResponse);
 });
 
 v2Router.delete("/:name+/blobs/uploads/:id", async (req, env: Env) => {
@@ -625,6 +652,7 @@ v2Router.head("/:name+/blobs/:tag", async (req, env: Env) => {
     headers: {
       "Content-Length": layerExistsResponse.size.toString(),
       "Docker-Content-Digest": layerExistsResponse.digest,
+      "Accept-Ranges": "bytes",
     },
   });
 });

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@ import { ManifestTagsListTooBigError } from "./v2-responses";
 import { Env } from "..";
 import { MINIMUM_CHUNK, MAXIMUM_CHUNK, MAXIMUM_CHUNK_UPLOAD_SIZE } from "./chunk";
 import {
+  BlobRangeRequest,
   CheckLayerResponse,
   CheckManifestResponse,
   FinishedUploadObject,
@@ -358,16 +359,25 @@ v2Router.get("/:name+/referrers/:digest", async (req, env: Env) => {
   );
 });
 
-// Parses a single HTTP byte range request of the form "bytes=<start>-" or "bytes=<start>-<end>".
-// Multi-range, suffix ("bytes=-<n>") and malformed values are ignored so the full object is served.
-function parseBlobRange(header: string | null): { offset: number; end?: number } | undefined {
+// Parses a single HTTP byte range request of the form "bytes=<start>-", "bytes=<start>-<end>" or
+// the suffix form "bytes=-<n>", which asks for the last n bytes.
+// Multi-range and malformed values are ignored so the full object is served.
+function parseBlobRange(header: string | null): BlobRangeRequest | undefined {
   if (header === null) return undefined;
-  const match = /^bytes=(\d+)-(\d*)$/.exec(header.trim());
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
   if (match === null) return undefined;
-  const offset = Number(match[1]);
+  const [, startValue, endValue] = match;
+  if (startValue === "") {
+    // "bytes=-" has neither a start nor a suffix length, so there is nothing to satisfy.
+    if (endValue === "") return undefined;
+    const suffix = Number(endValue);
+    return Number.isInteger(suffix) ? { suffix } : undefined;
+  }
+
+  const offset = Number(startValue);
   if (!Number.isInteger(offset)) return undefined;
-  if (match[2] === "") return { offset };
-  const end = Number(match[2]);
+  if (endValue === "") return { offset };
+  const end = Number(endValue);
   if (!Number.isInteger(end)) return { offset };
   return { offset, end };
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -418,6 +418,14 @@ v2Router.get("/:name+/blobs/:digest", async (req, env: Env, context: ExecutionCo
     const client = new RegistryHTTPClient(env, registry);
     const response = await client.getLayer(name, digest, range);
     if ("response" in response) {
+      // The blob exists upstream but the requested range doesn't fit it. Blobs are content
+      // addressed, so every registry holding this digest holds the same bytes and would answer the
+      // same way. Report it instead of letting it fall through to the 404 below, which would tell
+      // the client the blob doesn't exist and hide the object size it needs to retry.
+      if (response.response.status === 416) {
+        return response.response;
+      }
+
       continue;
     }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2362,6 +2362,74 @@ describe("garbage collector", () => {
   });
 });
 
+describe("blob range requests", () => {
+  async function uploadBlob(name: string, data: string): Promise<string> {
+    const sha256 = await getSHA256(data);
+    const res = await fetch(createRequest("POST", `/v2/${name}/blobs/uploads/`, null, {}));
+    expect(res.ok).toBeTruthy();
+    const stream = limit(new Blob([data]).stream(), data.length);
+    const res2 = await fetch(createRequest("PATCH", res.headers.get("location")!, stream, {}));
+    expect(res2.ok).toBeTruthy();
+    const last = await fetch(createRequest("PUT", res2.headers.get("location")! + "&digest=" + sha256, null, {}));
+    expect(last.ok).toBeTruthy();
+    return sha256;
+  }
+
+  const data = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+  test("open-ended Range returns 206 partial content from the offset", async () => {
+    const name = "range-open";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=10-" }));
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("content-range")).toEqual(`bytes 10-${data.length - 1}/${data.length}`);
+    expect(res.headers.get("content-length")).toEqual(`${data.length - 10}`);
+    expect(res.headers.get("accept-ranges")).toEqual("bytes");
+    expect(await res.text()).toEqual(data.slice(10));
+  });
+
+  test("bounded Range returns 206 partial content for the requested window", async () => {
+    const name = "range-bounded";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=5-14" }));
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("content-range")).toEqual(`bytes 5-14/${data.length}`);
+    expect(res.headers.get("content-length")).toEqual("10");
+    expect(await res.text()).toEqual(data.slice(5, 15));
+  });
+
+  test("no Range header keeps the existing full 200 behavior", async () => {
+    const name = "range-none";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null));
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-length")).toEqual(`${data.length}`);
+    expect(res.headers.get("content-range")).toBeNull();
+    expect(await res.text()).toEqual(data);
+  });
+
+  test("out-of-bounds Range returns 416 Range Not Satisfiable", async () => {
+    const name = "range-oob";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=100-200" }));
+    expect(res.status).toEqual(416);
+    expect(res.headers.get("content-range")).toEqual(`bytes */${data.length}`);
+  });
+
+  test("HEAD blob response advertises Accept-Ranges", async () => {
+    const name = "range-head";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("HEAD", `/v2/${name}/blobs/${digest}`, null));
+    expect(res.ok).toBeTruthy();
+    expect(res.headers.get("accept-ranges")).toEqual("bytes");
+  });
+});
+
 test("docker.io", () => {
   const t = [
     ["https://docker.io", true],

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1562,6 +1562,49 @@ describe("http client", () => {
     );
   });
 
+  test("test get layer forwards a suffix range and surfaces the partial content", async () => {
+    const name = "http-client-suffix-range";
+    const digest = numberedDigest(9950);
+    const body = "abcdefghij";
+
+    envBindings = { ...bindings };
+    envBindings.JWT_REGISTRY_TOKENS_PUBLIC_KEY = "";
+    envBindings.PASSWORD = "world";
+    envBindings.USERNAME = "hello";
+    envBindings.REGISTRIES_JSON = undefined;
+    const blobRequests: { path: string; range: string | null }[] = [];
+    using _fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      blobRequests.push({ path: url.pathname, range: request.headers.get("Range") });
+      return new Response(body.slice(-4), {
+        status: 206,
+        headers: { "Content-Range": `bytes 6-9/${body.length}` },
+      });
+    });
+
+    const client = new RegistryHTTPClient(envBindings, {
+      registry: "https://localhost",
+      password_env: "PASSWORD",
+      username,
+    });
+
+    const res = await client.getLayer(name, digest, { suffix: 4 });
+    if ("response" in res) {
+      expect(await res.response.json()).toEqual({ status: res.response.status });
+      throw new Error("expected getLayer to return partial content");
+    }
+
+    expect(blobRequests).toEqual([{ path: `/v2/${name}/blobs/${digest}`, range: "bytes=-4" }]);
+    expect(res.contentRange).toEqual({ start: 6, end: 9, size: body.length });
+    expect(res.size).toEqual(body.length);
+    expect(await new Response(res.stream).text()).toEqual(body.slice(-4));
+  });
+
   test("test list referrers selects rel next from multi-link headers", async () => {
     const name = "http-client-referrers-multilink";
     const subjectDigest = numberedDigest(9970);
@@ -2427,6 +2470,47 @@ describe("blob range requests", () => {
     const res = await fetch(createRequest("HEAD", `/v2/${name}/blobs/${digest}`, null));
     expect(res.ok).toBeTruthy();
     expect(res.headers.get("accept-ranges")).toEqual("bytes");
+  });
+
+  test("suffix Range returns 206 partial content with the last bytes", async () => {
+    const name = "range-suffix";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=-5" }));
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("content-range")).toEqual(`bytes ${data.length - 5}-${data.length - 1}/${data.length}`);
+    expect(res.headers.get("content-length")).toEqual("5");
+    expect(await res.text()).toEqual(data.slice(-5));
+  });
+
+  test("suffix Range longer than the blob returns the whole blob as partial content", async () => {
+    const name = "range-suffix-oversized";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=-1000" }));
+    expect(res.status).toEqual(206);
+    expect(res.headers.get("content-range")).toEqual(`bytes 0-${data.length - 1}/${data.length}`);
+    expect(res.headers.get("content-length")).toEqual(`${data.length}`);
+    expect(await res.text()).toEqual(data);
+  });
+
+  test("zero-length suffix Range returns 416 Range Not Satisfiable", async () => {
+    const name = "range-suffix-zero";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=-0" }));
+    expect(res.status).toEqual(416);
+    expect(res.headers.get("content-range")).toEqual(`bytes */${data.length}`);
+  });
+
+  test("Range header without a start or a suffix length keeps the full 200 behavior", async () => {
+    const name = "range-malformed";
+    const digest = await uploadBlob(name, data);
+
+    const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=-" }));
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-range")).toBeNull();
+    expect(await res.text()).toEqual(data);
   });
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -2514,6 +2514,86 @@ describe("blob range requests", () => {
   });
 });
 
+describe("blob range requests against fallback registries", () => {
+  const bindings = env as Env;
+  const data = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+  test("an upstream 416 is reported to the client instead of a 404", async () => {
+    const name = "range-fallback-unsatisfiable";
+    const digest = await getSHA256(data);
+    const previousRegistries = bindings.REGISTRIES_JSON;
+    bindings.REGISTRIES_JSON = JSON.stringify([{ registry: "https://fallback.registry" }]);
+    const blobRequests: { path: string; range: string | null }[] = [];
+    using _fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      blobRequests.push({ path: url.pathname, range: request.headers.get("Range") });
+      // The upstream holds the blob, but the requested range doesn't fit it.
+      const response = new Response(null, {
+        status: 416,
+        headers: { "Content-Range": `bytes */${data.length}`, "Accept-Ranges": "bytes" },
+      });
+      // A constructed Response has an empty url, which the client would read as a redirect.
+      Object.defineProperty(response, "url", { value: request.url });
+      return response;
+    });
+
+    try {
+      const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=100-200" }));
+      expect(blobRequests).toEqual([{ path: `/v2/${name}/blobs/${digest}`, range: "bytes=100-200" }]);
+      expect(res.status).toEqual(416);
+      expect(res.headers.get("content-range")).toEqual(`bytes */${data.length}`);
+    } finally {
+      bindings.REGISTRIES_JSON = previousRegistries;
+    }
+  });
+
+  test("a non-416 upstream failure still falls through to the next registry", async () => {
+    const name = "range-fallback-continue";
+    const digest = await getSHA256(data);
+    const previousRegistries = bindings.REGISTRIES_JSON;
+    bindings.REGISTRIES_JSON = JSON.stringify([
+      { registry: "https://broken.registry" },
+      { registry: "https://healthy.registry" },
+    ]);
+    const blobHosts: string[] = [];
+    using _fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const request = new Request(input as string | URL | Request, init);
+      const url = new URL(request.url);
+      if (url.pathname === "/v2/" || url.pathname === "/v2") {
+        return new Response(null, { status: 200 });
+      }
+
+      blobHosts.push(url.host);
+      if (url.host === "broken.registry") {
+        const failure = new Response("boom", { status: 500 });
+        // A constructed Response has an empty url, which the client would read as a redirect.
+        Object.defineProperty(failure, "url", { value: request.url });
+        return failure;
+      }
+
+      return new Response(data.slice(10), {
+        status: 206,
+        headers: { "Content-Range": `bytes 10-${data.length - 1}/${data.length}` },
+      });
+    });
+
+    try {
+      const res = await fetch(createRequest("GET", `/v2/${name}/blobs/${digest}`, null, { Range: "bytes=10-" }));
+      expect(blobHosts).toEqual(["broken.registry", "healthy.registry"]);
+      expect(res.status).toEqual(206);
+      expect(res.headers.get("content-range")).toEqual(`bytes 10-${data.length - 1}/${data.length}`);
+      expect(await res.text()).toEqual(data.slice(10));
+    } finally {
+      bindings.REGISTRIES_JSON = previousRegistries;
+    }
+  });
+});
+
 test("docker.io", () => {
   const t = [
     ["https://docker.io", true],


### PR DESCRIPTION
Originally the worker doesn't handle `Range` header, as a result, if a big layer connection drops, and the client try to resume the progress sending `Range` header, it will fail. The issue can be found #64

This PR implements the `Range` header forwarding to solve the problem