### PR TITLE
fix: pull-through fallback token scope for registries returning placeholder scope (e.g. ghcr.io)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules
 wrangler.toml
 wrangler.jsonc
 *.tsbuildinfo
+
+# local credentials & build artifacts
+registry-credentials.txt
+dist/

--- a/src/registry/http.ts
+++ b/src/registry/http.ts
@@ -293,7 +293,11 @@ export class RegistryHTTPClient implements Registry {
     }
 
     const authCtx = authHeaderIntoAuthContext(this.url, authenticateHeader);
-    if (!authCtx.scope) authCtx.scope = namespace;
+    // The scope returned by the upstream /v2/ endpoint is only a placeholder
+    // (e.g. ghcr.io returns "repository:user/image:pull"). Always use the
+    // namespace from the actual request, otherwise the scope ends up
+    // double-prefixed (repository:repository:...) and the token request fails.
+    authCtx.scope = namespace;
     switch (authCtx.authType) {
       case "bearer":
         return await this.authenticateBearer(authCtx);
@@ -331,7 +335,7 @@ export class RegistryHTTPClient implements Registry {
     const params = new URLSearchParams({
       service: ctx.service,
       // explicitely include that we don't want an offline_token.
-      scope: `repository:${ctx.scope}:pull,push`,
+      scope: `repository:${ctx.scope}:pull`,
       client_id: "r2registry",
       grant_type: this.configuration.username === undefined ? "none" : "password",
       password: this.configuration.username === undefined ? "" : this.password(),


### PR DESCRIPTION
Fixes #148

## Summary

Pull-through fallback to ghcr.io (and any registry whose `/v2/` endpoint returns a `scope` attribute in `WWW-Authenticate`) currently fails with `manifest unknown` (404). Two issues in `src/registry/http.ts`:

1. **Double-prefixed scope**: `authenticate()` only overrides the upstream scope when empty, but ghcr.io returns a placeholder scope (`repository:user/image:pull`), so `authenticateBearer()` builds `repository:repository:user/image:pull:pull,push` which the token endpoint rejects.

2. **Unnecessary push permission**: `authenticateBearer()` requests `:pull,push`, but ghcr.io's token endpoint returns `403 DENIED` for combined scopes and only accepts single `:pull`. Fallback is read-only, so push permission is not needed.

## Changes

`src/registry/http.ts`:
- Always use the request namespace for the token scope, ignoring the placeholder scope returned by upstream `/v2/`
- Request only `:pull` permission instead of `:pull,push`

## Verification

Tested against a deployed instance with `REGISTRIES_JSON` = Docker Hub + ghcr.io + registry.k8s.io + quay.io + gcr.io:

| Registry | Image | Before | After |
|---|---|---|---|
| ghcr.io | actions/actions-runner | 404 | 200 |
| ghcr.io | home-assistant/home-assistant | 404 | 200 |
| ghcr.io | open-telemetry/opentelemetry-collector-releases/opentelemetry-collector | 404 | 200 |
| docker.io | library/alpine | 200 | 200 |
| registry.k8s.io | pause | 200 | 200 |
| quay.io | prometheus/node-exporter | 200 | 200 |
| gcr.io | google-containers/pause | 200 | 200 |