### PR TITLE
push: survive a cold cache and a leftover extraction directory

### DIFF
--- a/push/index.ts
+++ b/push/index.ts
@@ -69,7 +69,9 @@ if (!(await file(tarFile).exists())) {
 
   console.log(`Image saved as ${tarFile}, extracting...`);
 
-  await mkdir(imagePath);
+  // recursive, so a leftover .output-image from an interrupted run does not
+  // make this throw EEXIST.
+  await mkdir(imagePath, { recursive: true });
 
   await extract({
     file: tarFile,
@@ -131,7 +133,9 @@ for (const layer of manifest.Layers) {
       }
 
       const inprogressPath = path.join(cacheFolder, layerName + "-in-progress");
-      await rm(inprogressPath, { recursive: true });
+      // force, because on a cold cache there is nothing to remove and rm would
+      // throw ENOENT, which made the very first run of the tool always fail.
+      await rm(inprogressPath, { recursive: true, force: true });
 
       const hasher = new Bun.CryptoHasher("sha256");
       const cacheWriter = file(inprogressPath).writer();


### PR DESCRIPTION
The chunked pusher in `push/` fails on its very first run against a fresh checkout.

## `rm` without `force`

`fs/promises.rm` throws `ENOENT` when the target is absent; `force: true` is what suppresses that. The in-progress cache entry is removed before it is ever written:

```ts
const inprogressPath = path.join(cacheFolder, layerName + "-in-progress");
await rm(inprogressPath, { recursive: true });
```

On a cold cache that file cannot exist yet, so the first push always dies here:

```
ENOENT: no such file or directory, lstat '.cache/<digest>-in-progress'
    at async <anonymous> (push/index.ts:134:13)
```

Reproduces with `rm -rf push/.cache` followed by a push of any image.

## `mkdir` without `recursive`

`mkdir(imagePath)` throws `EEXIST` when `.output-image` is already present. It is only reached inside the `if (!(await file(tarFile).exists()))` branch, so a run interrupted after extraction, whose `.tar` was later removed, cannot be retried without deleting the directory by hand.

## Verified

With both changes, pushing a single-layer 400MB image from a cold cache succeeded, chunked at the advertised `OCI-Chunk-Max-Length` of 100MB, and `docker pull` returned it intact.